### PR TITLE
feat(config): allow pkg as abbreviation of package 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/eslint-config",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "type": "module",
   "description": "",
   "homepage": "https://github.com/poupe-ui/eslint-config",

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -70,6 +70,9 @@ export const rules: Rules = {
         opts: {
           options: false,
         },
+        pkg: {
+          package: false,
+        },
         param: {
           parameter: false,
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package version from 0.4.8 to 0.4.9
	- Enhanced linting configuration by adding an abbreviation rule for `pkg`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->