### PR TITLE
chore(config): use space-2 for all json files and set vscode language to en-GB

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,11 +10,7 @@ indent_size = 8
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{yaml,yml,js,cjs,mjs,ts}]
-indent_style = space
-indent_size = 2
-
-[{package,tsconfig}.json]
+[*.{json,yaml,yml,js,cjs,mjs,ts,vue,css}]
 indent_style = space
 indent_size = 2
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "cSpell.language": "en-GB",
   "cSpell.words": [
     "amery",
     "apptly",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-    "cSpell.words": [
-        "amery",
-        "apptly",
-        "nuxt",
-        "poupe",
-        "TSES"
-    ]
+  "cSpell.words": [
+    "amery",
+    "apptly",
+    "nuxt",
+    "poupe",
+    "TSES"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "declaration": true
   },
   "include": [
-    "src",
+    "src"
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Consolidated formatting rules to provide consistent indentation across a broader range of file types.
	- Updated spell-check settings to support British English.
	- Refined project configuration for enhanced consistency in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->