### PR TITLE
fix(nuxt): don't add unicorn rules to nuxt modules

### DIFF
--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -9,11 +9,10 @@ import {
 
 type Config = Linter.Config;
 
-const { plugins: unicornPlugins, ...unicornConfig } = unicornConfigs['flat/recommended'];
+const { plugins: unicornPlugins, ...unicornConfig } = unicornConfigs.recommended;
 
 const sharedNuxtRules: Config[] = [
   tsdocConfigs.recommended,
-  unicornConfig,
   {
     name: 'poupe/files',
     files,
@@ -29,6 +28,7 @@ export const forNuxt = (...userConfigs: Config[]) => [
   {
     plugins: unicornPlugins,
   },
+  unicornConfig,
   ...sharedNuxtRules,
   ...userConfigs,
 ];


### PR DESCRIPTION
due to version conflict

packages/@poupe-nuxt lint: TypeError: Key "rules": Key "unicorn/no-unnecessary-array-flat-depth": Could not find "no-unnecessary-array-flat-depth" in plugin "unicorn".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the internal configuration order for improved organization. No changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->