### PR TITLE
docs: convert CLAUDE.md to AGENT.md with git workflow guidelines

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -81,7 +81,7 @@ Follow these conventions (enforced by .editorconfig and ESLint):
 - **Trailing Whitespace**: Always trim (except in Markdown files)
 - **Default Indentation**: 8-space tabs for most files
 - **Special Indentation**:
-  - 2 spaces for: `.json`, `.yaml`, `.yml`, `.js`, `.cjs`, `.mjs`, `.ts`,
+  - 2 spaces for `.json`, `.yaml`, `.yml`, `.js`, `.cjs`, `.mjs`, `.ts`,
     `.vue`, `.css`, `.md`
 
 ### ESLint Enforced Rules
@@ -147,6 +147,22 @@ export default [
 ];
 ```
 
+## Git Workflow
+
+### Commit Guidelines
+- Always use `-s` flag for signed commits
+- Never use `-m` flag
+- Use `-F` flag with a commit message file
+- Create unique commit message files: `.commit-msg-<timestamp>` in CWD
+- Delete commit message files after use to avoid conflicts
+- Always specify explicit file names in the commit command
+- Use the Write tool to create commit message files (avoid echo/heredoc to
+  prevent shell expansion issues)
+- Example workflow:
+  1. Use Write tool to create `.commit-msg-<timestamp>`
+  2. Run: `git commit -s -F .commit-msg-<timestamp> file1 file2`
+  3. Delete the commit message file after use
+
 ## Development Practices
 
 ### DO:
@@ -155,6 +171,7 @@ export default [
 - Follow existing patterns when adding new configurations
 - Use semantic versioning for releases
 - Follow the .editorconfig rules for consistent formatting
+- Use atomic commits with explicit file lists
 
 ### DON'T:
 - Create files unless necessary - prefer editing existing configurations
@@ -162,3 +179,5 @@ export default [
 - Ignore TypeScript errors or ESLint warnings
 - Mix different configuration styles (stick to flat config format)
 - Mix tabs and spaces - follow the .editorconfig rules for each file type
+- Use `git commit -m` (use `-F` with a file instead)
+- Rely on staged files - always specify files explicitly in commits

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,11 +1,13 @@
-# CLAUDE.md
+# AGENT.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI assistants when working with code in this
+repository.
 
 ## Commands
 
 ### Development Commands
-- `pnpm build` - Build the package using unbuild (required before testing changes)
+- `pnpm build` - Build the package using unbuild (required before testing
+  changes)
 - `pnpm lint` - Run ESLint with auto-fix enabled
 - `pnpm type-check` - Check TypeScript types without emitting files
 - `pnpm dev:prepare` - Create a fast stub build for development
@@ -19,20 +21,27 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 To test ESLint configuration changes:
 1. Make changes to configuration files in `src/configs/`
 2. Run `pnpm build` to compile the package
-3. Run `pnpm lint` to test the configuration on this codebase itself (self-linting)
+3. Run `pnpm lint` to test the configuration on this codebase itself
+   (self-linting)
 
 ## Architecture
 
-This is a shareable ESLint configuration package that provides standardized linting rules for Poupe UI projects. It uses ESLint's flat configuration format and is written in TypeScript.
+This is a shareable ESLint configuration package that provides standardized
+linting rules for Poupe UI projects. It uses ESLint's flat configuration
+format and is written in TypeScript.
 
 ### Key Concepts
-1. **Flat Config Format**: Uses ESLint's modern flat configuration system (not legacy .eslintrc)
-2. **Configuration Composition**: The package combines multiple ESLint plugins with custom rule overrides
+1. **Flat Config Format**: Uses ESLint's modern flat configuration system
+   (not legacy .eslintrc)
+2. **Configuration Composition**: The package combines multiple ESLint plugins
+   with custom rule overrides
 3. **Entry Points**:
    - Main: `@poupe/eslint-config` for standard projects
    - Nuxt: `@poupe/eslint-config/nuxt` for Nuxt.js projects
-4. **Type Safety**: Full TypeScript support with proper type definitions exported from `src/core/types.ts`
-5. **Self-Dogfooding**: Package uses its own ESLint configuration for validation
+4. **Type Safety**: Full TypeScript support with proper type definitions
+   exported from `src/core/types.ts`
+5. **Self-Dogfooding**: Package uses its own ESLint configuration for
+   validation
 
 ### Configuration Structure
 ```
@@ -64,20 +73,29 @@ src/
 ## Code Style Guidelines
 
 Follow these conventions (enforced by .editorconfig and ESLint):
-- **Indentation**: 2 spaces for TypeScript/JavaScript/JSON files
-- **Line Endings**: Unix (LF)
+
+### EditorConfig Rules
 - **Charset**: UTF-8
+- **Line Endings**: Unix (LF)
+- **Final Newline**: Always insert
+- **Trailing Whitespace**: Always trim (except in Markdown files)
+- **Default Indentation**: 8-space tabs for most files
+- **Special Indentation**:
+  - 2 spaces for: `.json`, `.yaml`, `.yml`, `.js`, `.cjs`, `.mjs`, `.ts`,
+    `.vue`, `.css`, `.md`
+
+### ESLint Enforced Rules
 - **Quotes**: Single quotes for strings
 - **Semicolons**: Always use semicolons
 - **Brace Style**: 1tbs (one true brace style)
-- **Naming**: camelCase for variables/functions, PascalCase for types/interfaces
-- **Final Newline**: Always insert
-- **Trailing Whitespace**: Always trim
+- **Naming**: camelCase for variables/functions, PascalCase for
+  types/interfaces
 
 ## Common Tasks
 
 ### Adding or Modifying Rules
-1. Locate the appropriate config file in `src/configs/` (e.g., `eslint.ts` for JavaScript rules)
+1. Locate the appropriate config file in `src/configs/` (e.g., `eslint.ts`
+   for JavaScript rules)
 2. Modify the rules object within the configuration
 3. Run `pnpm build` then `pnpm lint` to test your changes
 
@@ -96,8 +114,10 @@ The package uses `unbuild` which:
 - Compiles TypeScript to both ESM (.mjs) and CommonJS (.cjs)
 - Generates TypeScript declaration files
 - Creates stub builds for faster development iteration
-- The `eslint-flat-config-utils` package is marked as external in `build.config.ts`
-- Outputs: `dist/index.mjs`, `dist/index.cjs`, `dist/nuxt.mjs`, `dist/nuxt.cjs`
+- The `eslint-flat-config-utils` package is marked as external in
+  `build.config.ts`
+- Outputs: `dist/index.mjs`, `dist/index.cjs`, `dist/nuxt.mjs`,
+  `dist/nuxt.cjs`
 
 ## Usage Examples
 ```typescript
@@ -134,9 +154,11 @@ export default [
 - Test configuration changes by running lint on this codebase
 - Follow existing patterns when adding new configurations
 - Use semantic versioning for releases
+- Follow the .editorconfig rules for consistent formatting
 
 ### DON'T:
 - Create files unless necessary - prefer editing existing configurations
 - Add external dependencies without careful consideration
 - Ignore TypeScript errors or ESLint warnings
 - Mix different configuration styles (stick to flat config format)
+- Mix tabs and spaces - follow the .editorconfig rules for each file type

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ export default defineConfig({
 });
 ```
 
+## Development
+
+For AI assistants working with this codebase, refer to [AGENT.md](./AGENT.md)
+for detailed guidance and conventions.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Converted CLAUDE.md to AGENT.md for broader AI assistant compatibility
- Added git workflow guidelines including commit best practices
- Updated README.md to reference AGENT.md for AI assistant guidance

## Changes
- **AGENT.md**: 
  - Renamed from CLAUDE.md for broader applicability
  - Enforced 80-character line limit throughout
  - Added comprehensive git workflow section with commit guidelines
  - Incorporated .editorconfig rules into code style guidelines
  - Fixed typo in indentation rules (removed colon before "for")
- **README.md**: Added Development section referencing AGENT.md

## Git Workflow Guidelines Added
- Always use `-s` flag for signed commits
- Use `-F` flag with commit message files (never `-m`)
- Create unique `.commit-msg-<timestamp>` files
- Always specify explicit file names in commits
- Use Write tool for commit messages to avoid shell expansion issues

## Test plan
- [x] Verify 80-character line limit is maintained
- [x] Confirm .editorconfig rules are properly documented
- [x] Check all markdown formatting is correct
- [x] Address CodeRabbit feedback on formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to generalize guidance for AI assistants and clarify formatting, workflow, and development practices.
  - Expanded code style and commit guidelines, including a new section on Git workflow.
  - Added a "Development" section to the README, directing users to the detailed guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->