### PR TITLE
feat(css): implement smart rule filtering system with VSCode JSON and markdown fixes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -102,6 +102,42 @@ The configuration automatically lints the following file types:
 - **Markdown**: `.md`
 - **CSS**: `.css` (with Tailwind CSS syntax support)
 
+### CSS Configuration System
+
+The CSS configuration (`src/configs/css.ts`) uses a sophisticated filtering
+system to apply appropriate rules to CSS files:
+
+#### Rule Filtering Architecture
+
+1. **ALWAYS_KEEP_PLUGINS**: Plugins where all rules work with CSS files
+   - `css`, `jsonc`, `markdown`
+
+2. **ALWAYS_DISABLE_PLUGINS**: Plugins where no rules work with CSS files
+   - Core ESLint rules (`''`), `@typescript-eslint`, `vue`, `tsdoc`
+
+3. **KNOWN_PLUGINS**: Plugins requiring fine-grained rule control
+   - Each plugin has a `PluginRuleConfig` with:
+     - `alwaysKeepRules`: Specific rules to keep for CSS files
+     - `alwaysDisableRules`: Specific rules to disable for CSS files
+     - `alwaysKeepPatterns`: RegExp patterns for rules to keep
+     - `alwaysDisablePatterns`: RegExp patterns for rules to disable
+
+4. **Dynamic Detection**: Unknown plugins/rules are automatically handled
+   - Unknown plugin → Warning + add to ALWAYS_DISABLE_PLUGINS
+   - Unknown rule in known plugin → Warning + add to alwaysDisableRules
+
+#### Adding CSS Support for New Plugins
+
+When adding a new ESLint plugin that might have CSS-relevant rules:
+
+1. Analyze which rules make sense for CSS files
+2. Add the plugin to the appropriate category:
+   - If all rules work with CSS → ALWAYS_KEEP_PLUGINS
+   - If no rules work with CSS → ALWAYS_DISABLE_PLUGINS
+   - If mixed → Add to KNOWN_PLUGINS with detailed configuration
+3. Run `pnpm lint` to see warnings for uncategorized rules
+4. Use the warnings to populate your rule sets
+
 ## Code Style Guidelines
 
 Follow these conventions (enforced by .editorconfig and ESLint):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.5] - 2025-06-20
+
+### Added
+
+- **poupeCssRules export**: New rules configuration specifically for CSS files
+  with Tailwind CSS v4 compatibility
+- **Smart CSS rule filtering**: Implemented intelligent filtering system that
+  scans all plugin rules (not just configured ones) to properly categorize
+  which rules apply to CSS files
+- **VSCode JSON comments**: Allow comments in VSCode configuration files
+  (`**/.vscode/*.json`) while maintaining strict no-comment rules for regular
+  JSON files
+
+### Fixed
+
+- **CSS rule application**: Fixed issue where `unicorn/filename-case` was
+  incorrectly disabled for CSS files
+- **Complete rule coverage**: Now properly disables ~280 JavaScript-specific
+  rules for CSS files by scanning plugin rules directly
+- **Stylistic rules for CSS**: Correctly keeps formatting rules like `eol-last`,
+  `no-trailing-spaces`, and `spaced-comment` that work with CSS files
+- **Markdown indentation**: Set explicit 2-space indentation for MD007 rule
+  (unordered list indentation) to ensure consistent formatting
+
+### Changed
+
+- **CSS configuration architecture**: Replaced hardcoded plugin lists with a
+  flexible configuration system supporting per-plugin rule sets and patterns
+
 ## [0.7.4] - 2025-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ export default defineConfig({
 });
 ```
 
+## CSS Support
+
+This configuration includes advanced CSS linting with Tailwind CSS v4 syntax
+support. The CSS configuration uses an intelligent filtering system that:
+
+* Applies CSS-specific rules from `@eslint/css`
+* Supports Tailwind CSS v4 syntax including theme functions and modifiers
+* Automatically disables JavaScript-specific rules for CSS files
+* Keeps relevant cross-language rules (like `filename-case` from unicorn)
+
+The filtering system categorizes plugins and rules to ensure only appropriate
+rules apply to CSS files. See [AGENT.md](./AGENT.md#css-configuration-system)
+for implementation details.
+
 ## Examples
 
 The `examples/` directory contains working examples demonstrating how to use

--- a/__tests__/json.test.ts
+++ b/__tests__/json.test.ts
@@ -6,11 +6,11 @@ describe('JSON Configuration', () => {
   describe('jsoncRecommended', () => {
     it('should export an array of configurations', () => {
       expect(Array.isArray(jsoncRecommended)).toBe(true);
-      expect(jsoncRecommended).toHaveLength(2);
+      expect(jsoncRecommended).toHaveLength(3);
     });
 
-    it('should have separate configs for general JSON and package.json', () => {
-      const [generalConfig, packageJsonConfig] = jsoncRecommended;
+    it('should have separate configs for general JSON, package.json, and VSCode', () => {
+      const [generalConfig, packageJsonConfig, vscodeConfig] = jsoncRecommended;
 
       expect(generalConfig.name).toBe('jsonc/json');
       expect(generalConfig.files).toContain('**/*.json');
@@ -18,12 +18,21 @@ describe('JSON Configuration', () => {
 
       expect(packageJsonConfig.name).toBe('jsonc/package-json');
       expect(packageJsonConfig.files).toContain('**/package.json');
+
+      expect(vscodeConfig.name).toBe('jsonc/allow-comments');
+      expect(vscodeConfig.files).toContain('**/.vscode/*.json');
     });
 
     it('should include jsonc plugin and parser', () => {
       for (const config of jsoncRecommended) {
-        expect(config.plugins).toHaveProperty('jsonc');
-        expect(config.languageOptions?.parser).toBeDefined();
+        // VSCode config only has rule overrides, no plugin/parser
+        if (config.name === 'jsonc/allow-comments') {
+          expect(config.plugins).toBeUndefined();
+          expect(config.languageOptions).toBeUndefined();
+        } else {
+          expect(config.plugins).toHaveProperty('jsonc');
+          expect(config.languageOptions?.parser).toBeDefined();
+        }
       }
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/eslint-config",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/src/configs/css.ts
+++ b/src/configs/css.ts
@@ -111,6 +111,11 @@ const KNOWN_PLUGINS = new Map<string, PluginRuleConfig>([
       'no-abusive-eslint-disable', // ESLint directives work differently in CSS
       'prefer-at', // Array.at() method - JS only
       'prefer-event-target', // EventTarget API - JS only
+      'better-regex', // RegExp optimization - JS only
+      'no-keyword-prefix', // JS keyword prefixing - JS only
+      'no-unused-properties', // Object property detection - JS only
+      'string-content', // String content patterns - JS only
+      'no-length-as-slice-end', // Array slice method - JS only
     ],
     undefined, // No keep patterns
     [
@@ -215,6 +220,16 @@ const KNOWN_PLUGINS = new Map<string, PluginRuleConfig>([
     [
       'max-len', // CSS can have long lines (selectors, Tailwind classes)
       'no-multi-spaces', // CSS often aligns property values
+      'func-call-spacing', // JS function call spacing - not for CSS functions
+      'implicit-arrow-linebreak', // Arrow function formatting - JS only
+      'line-comment-position', // JS line comments - CSS uses block comments
+      'linebreak-style', // Line endings - handled by .editorconfig
+      'newline-per-chained-call', // Method chaining - JS only
+      'no-confusing-arrow', // Arrow function clarity - JS only
+      'nonblock-statement-body-position', // Control flow formatting - JS only
+      'one-var-declaration-per-line', // JS variable declarations - not CSS vars
+      'padding-line-between-statements', // JS statement padding - not CSS rules
+      'switch-colon-spacing', // Switch statements - JS only
     ],
     undefined, // No keep patterns
     [

--- a/src/configs/css.ts
+++ b/src/configs/css.ts
@@ -1,8 +1,11 @@
 import css from '@eslint/css';
 import { tailwindSyntax } from '@eslint/css/syntax';
+import unicornPlugin from 'eslint-plugin-unicorn';
+import stylisticPlugin from '@stylistic/eslint-plugin';
 
 import type {
   Linter,
+  Rules,
 } from '../core/types';
 
 import { tailwindV4Syntax } from './tailwind-v4-syntax';
@@ -11,6 +14,71 @@ import { unicornRecommended, poupeUnicornRules } from './unicorn';
 import { stylisticRecommended, poupeStylisticRules } from './stylistic';
 
 const { configs: cssConfigs } = css;
+
+// Helper function for safe console warnings
+function warn(message: string): void {
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn(`[@poupe/eslint-config] ${message}`);
+  }
+}
+
+// Poupe-specific CSS rules
+export const poupeCssRules: Rules = {
+  // Tailwind CSS v4 compatibility
+  'css/no-invalid-at-rules': 'off', // Allow Tailwind @ rules
+  'css/no-parsing-errors': 'off', // Allow Tailwind modifiers syntax
+
+  // CSS best practices (when @eslint/css adds more rules)
+  // Future rules could include:
+  // - 'css/color-format': ['error', 'lowercase'] // Enforce lowercase hex
+  // - 'css/property-order': ['error', 'alphabetical'] // Property ordering
+  // - 'css/quote-style': ['error', 'double'] // Prefer double quotes in CSS
+  // - 'css/unit-no-unknown': 'error' // Disallow unknown units
+  // - 'css/declaration-block-no-duplicate-properties': 'error'
+};
+
+// Configuration for which plugin rules to keep/disable for CSS files
+interface PluginRuleConfig {
+  // Plugin name for prefixing rules
+  pluginName: string
+  // Rules to always keep enabled (without plugin prefix)
+  alwaysKeepRules: Set<string>
+  // Rules to always disable (without plugin prefix)
+  alwaysDisableRules: Set<string>
+  // Rule patterns to keep enabled (RegExp, tested against rule name without prefix)
+  alwaysKeepPatterns: RegExp[]
+  // Rule patterns to disable (RegExp, tested against rule name without prefix)
+  alwaysDisablePatterns: RegExp[]
+}
+
+// Factory function to create PluginRuleConfig
+function createPluginConfig(
+  pluginName: string,
+  keepRules?: string[],
+  disableRules?: string[],
+  keepPatterns?: RegExp[],
+  disablePatterns?: RegExp[],
+): PluginRuleConfig {
+  return {
+    pluginName,
+    alwaysKeepRules: new Set(keepRules ?? []),
+    alwaysDisableRules: new Set(disableRules ?? []),
+    alwaysKeepPatterns: keepPatterns ?? [],
+    alwaysDisablePatterns: disablePatterns ?? [],
+  };
+}
+
+// Helper function to split rule name into plugin and rule parts
+function splitRuleName(ruleName: string): { pluginName: string; rulePart: string } {
+  const slashIndex = ruleName.indexOf('/');
+  if (slashIndex === -1) {
+    return { pluginName: '', rulePart: ruleName };
+  }
+  return {
+    pluginName: ruleName.slice(0, slashIndex),
+    rulePart: ruleName.slice(slashIndex + 1),
+  };
+}
 
 // 1. Plugins to always keep (all rules work with CSS)
 const ALWAYS_KEEP_PLUGINS = new Set([
@@ -22,42 +90,179 @@ const ALWAYS_KEEP_PLUGINS = new Set([
 // 2. Plugins to always disable (no rules work with CSS)
 const ALWAYS_DISABLE_PLUGINS = new Set([
   '', // Core ESLint rules
-  'unicorn',
   '@typescript-eslint',
   'vue',
   'tsdoc',
 ]);
 
-// 3. Plugins with specific rules to disable
-const PLUGIN_RULES_TO_DISABLE = new Map<string, Set<string>>([
-  ['@stylistic', new Set([
-    '@stylistic/indent',
-    '@stylistic/semi',
-    '@stylistic/comma-dangle',
-    '@stylistic/brace-style',
-    '@stylistic/object-curly-spacing',
-    '@stylistic/no-extra-semi',
-  ])],
+// 3. Known plugins with complex rule configurations
+const KNOWN_PLUGINS = new Map<string, PluginRuleConfig>([
+  ['unicorn', createPluginConfig(
+    'unicorn',
+    // Rules that make sense for CSS files (file-agnostic rules)
+    [
+      'filename-case', // File naming conventions
+      'no-empty-file', // Empty files are usually mistakes
+    ],
+    // Rules to explicitly disable
+    [
+      'empty-brace-spaces', // JS object braces, not CSS blocks
+      'expiring-todo-comments', // TODO comments work differently in CSS
+      'no-abusive-eslint-disable', // ESLint directives work differently in CSS
+      'prefer-at', // Array.at() method - JS only
+      'prefer-event-target', // EventTarget API - JS only
+    ],
+    undefined, // No keep patterns
+    [
+      // Disable all JavaScript-specific patterns
+      /^consistent-/, // JavaScript consistency rules
+      /^no-array/, // Array-specific rules
+      /^no-.*-assignment/, // Assignment rules
+      /^no-.*-expression/, // Expression rules
+      /^no-.*-statement/, // Statement rules
+      /^no-.*-recursion/, // Recursion rules
+      /^no-.*-spaces/, // Space-related rules (JS-specific)
+      /^no-.*-default/, // Default export/parameter rules
+      /^no-console/, // Console rules
+      /^no-document/, // Document API rules
+      /^no-for/, // Loop rules
+      /^no-hex/, // Hex escape rules (JS strings)
+      /^no-invalid/, // Invalid JS constructs
+      /^no-lonely/, // Control flow rules
+      /^no-magic/, // Magic number/array rules
+      /^no-named/, // Named export rules
+      /^no-negat/, // Negation rules
+      /^no-new/, // Constructor rules
+      /^no-object/, // Object rules
+      /^no-process/, // Process rules
+      /^no-single/, // Single element rules
+      /^no-static/, // Static class rules
+      /^no-thenable/, // Promise rules
+      /^no-this/, // This binding rules
+      /^no-typeof/, // Typeof rules
+      /^no-unnecessary/, // Unnecessary code rules
+      /^no-unreadable/, // Readability rules (JS-specific)
+      /^no-useless/, // Useless code rules
+      /^no-zero/, // Zero fraction rules
+      /^prefer-array/, // Array preference rules
+      /^prefer-.*-method/, // Method preference rules
+      /^prefer-dom/, // DOM-specific rules
+      /^prefer-string/, // String method rules
+      /^prefer-number/, // Number method rules
+      /^prefer-object/, // Object method rules
+      /^prefer-regexp/, // RegExp rules
+      /^prefer-.*-event/, // Event handling rules
+      /^prefer-.*-api/, // API usage rules
+      /^prefer-.*-parameters/, // Parameter rules
+      /^prefer-blob/, // Blob API rules
+      /^prefer-code/, // Code point rules
+      /^prefer-date/, // Date rules
+      /^prefer-includes/, // Array includes rules
+      /^prefer-global/, // Global object rules
+      /^prefer-keyboard/, // Keyboard event rules
+      /^prefer-logical/, // Logical operator rules
+      /^prefer-math/, // Math API rules
+      /^prefer-modern/, // Modern API rules
+      /^prefer-native/, // Native function rules
+      /^prefer-negative/, // Negative index rules
+      /^prefer-node/, // Node.js rules
+      /^prefer-optional/, // Optional chaining rules
+      /^prefer-prototype/, // Prototype rules
+      /^prefer-query/, // Query selector rules
+      /^prefer-reflect/, // Reflect API rules
+      /^prefer-set/, // Set rules
+      /^prefer-single/, // Single call rules
+      /^prefer-spread/, // Spread rules
+      /^prefer-structured/, // Structured clone rules
+      /^prefer-switch/, // Switch rules
+      /^prefer-ternary/, // Ternary rules
+      /^prefer-top/, // Top-level await rules
+      /^prefer-type/, // Type error rules
+      /^require-/, // Requirement rules
+      /^prevent-/, // Prevention rules
+      /^relative-/, // URL rules
+      /catch|error|throw/, // Error handling rules
+      /function|callback|async|await/, // Function-related rules
+      /import|export|module/, // Module system rules
+      /promise|thenable/, // Promise-related rules
+      /class|prototype|this/, // OOP-related rules
+      /switch|ternary|condition/, // Control flow rules
+      /typeof|instanceof/, // Type checking rules
+      /null|undefined/, // Null/undefined handling
+      /template/, // Template literal rules
+      /array|buffer/, // Array/Buffer rules
+      /numeric-separators/, // Numeric separator rules
+      /builtin/, // Built-in rules
+      /abbreviation/, // Abbreviation rules
+      /explicit-length/, // Explicit length rules
+      /escape-case/, // Escape case rules
+      /number-literal/, // Number literal rules
+      /text-encoding/, // Text encoding rules
+    ],
+  )],
+  ['@stylistic', createPluginConfig(
+    '@stylistic',
+    // Rules that make sense for CSS files
+    [
+      'eol-last', // Always end files with newline
+      'no-trailing-spaces', // No trailing whitespace
+      'no-multiple-empty-lines', // Limit consecutive empty lines
+      'no-mixed-spaces-and-tabs', // Consistent indentation
+      'spaced-comment', // Require space after /* in comments
+      'no-tabs', // Use spaces, not tabs (CSS convention)
+    ],
+    // Rules to explicitly disable
+    [
+      'max-len', // CSS can have long lines (selectors, Tailwind classes)
+      'no-multi-spaces', // CSS often aligns property values
+    ],
+    undefined, // No keep patterns
+    [
+      // Disable all JavaScript-specific patterns
+      /^array-/, // Array formatting
+      /^arrow-/, // Arrow function formatting
+      /^block-/, // Block statement formatting
+      /^brace-/, // Brace formatting
+      /^comma-/, // Comma formatting (JS-specific)
+      /^computed-/, // Computed property formatting
+      /^dot-/, // Member access formatting
+      /^function-/, // Function formatting
+      /^generator-/, // Generator formatting
+      /^jsx-/, // JSX formatting
+      /^key-/, // Object key formatting
+      /^keyword-/, // Keyword spacing
+      /^lines-/, // Line-based rules (JS-specific)
+      /^max-/, // Max rules (JS-specific metrics)
+      /^member-/, // Member formatting
+      /^new-/, // Constructor formatting
+      /^object-/, // Object formatting
+      /^operator-/, // Operator formatting
+      /^paren/, // Parenthesis formatting
+      /^quote/, // Quote formatting
+      /^rest-/, // Rest parameter formatting
+      /^semi/, // Semicolon rules
+      /^space-/, // Space rules (JS-specific)
+      /^template-/, // Template literal formatting
+      /^type-/, // TypeScript type formatting
+      /^wrap-/, // Wrapping rules
+      /^yield-/, // Yield formatting
+      /indent/, // Indentation (too JS-specific)
+      /bracket/, // Bracket formatting
+      /curly/, // Curly brace formatting
+      /padded-blocks/, // Block padding (JS-specific)
+      /no-extra-/, // Extra character rules (JS-specific)
+      /no-floating/, // Number formatting
+      /no-mixed-operators/, // Operator mixing (JS-specific)
+      /no-whitespace/, // Whitespace before property (JS-specific)
+      /multiline/, // Multiline constructs (JS-specific)
+    ],
+  )],
 ]);
 
-// 4. Plugins with patterns to disable
-const PLUGIN_PATTERNS_TO_DISABLE = new Map<string, RegExp[]>([
-  ['@stylistic', [
-    /function/,
-    /arrow/,
-    /member/,
-    /type-/,
-    /jsx/,
-    /template/,
-    /generator/,
-  ]],
-]);
-
-// Analyze a config and add JavaScript-specific rules to the Set
-function analyzeConfigForJSRules(
+// Analyze a config and process rules for CSS files
+function analyzeConfigForCSSRules(
   config: Linter.Config | Record<string, unknown>,
   rulesToDisable: Set<string>,
-  unknownPlugins: Set<string>,
 ): void {
   const rules = 'rules' in config ? config.rules : config;
   if (!rules) return;
@@ -66,8 +271,8 @@ function analyzeConfigForJSRules(
     // Skip if already disabled
     if (ruleValue === 'off' || ruleValue === 0) continue;
 
-    // Get the plugin name
-    const pluginName = ruleName.includes('/') ? ruleName.split('/')[0] : '';
+    // Split the rule name
+    const { pluginName, rulePart } = splitRuleName(ruleName);
 
     // 1. Skip if it's a plugin we always keep
     if (ALWAYS_KEEP_PLUGINS.has(pluginName)) continue;
@@ -78,26 +283,42 @@ function analyzeConfigForJSRules(
       continue;
     }
 
-    // 3. Check specific rules to disable
-    const specificRules = PLUGIN_RULES_TO_DISABLE.get(pluginName);
-    if (specificRules?.has(ruleName)) {
+    // 3. Check known plugins with complex configurations
+    const pluginConfig = KNOWN_PLUGINS.get(pluginName);
+    if (pluginConfig) {
+      // Check if it's in always keep rules
+      if (pluginConfig.alwaysKeepRules.has(rulePart)) {
+        continue;
+      }
+
+      // Check if it's in always disable rules
+      if (pluginConfig.alwaysDisableRules.has(rulePart)) {
+        rulesToDisable.add(ruleName);
+        continue;
+      }
+
+      // Check keep patterns
+      if (pluginConfig.alwaysKeepPatterns.some(pattern => pattern.test(rulePart))) {
+        continue;
+      }
+
+      // Check disable patterns
+      if (pluginConfig.alwaysDisablePatterns.some(pattern => pattern.test(rulePart))) {
+        rulesToDisable.add(ruleName);
+        continue;
+      }
+
+      // Rule doesn't match anything - warn and add to disable set
+      warn(`Unknown rule '${ruleName}' in CSS config. Adding to disable set.`);
+      pluginConfig.alwaysDisableRules.add(rulePart);
       rulesToDisable.add(ruleName);
       continue;
     }
 
-    // 4. Check patterns to disable
-    const patterns = PLUGIN_PATTERNS_TO_DISABLE.get(pluginName);
-    if (patterns?.some(pattern => pattern.test(ruleName))) {
-      rulesToDisable.add(ruleName);
-      continue;
-    }
-
-    // If not handled by any of the above, it's an unknown plugin
-    // For safety, disable unknown plugin rules for CSS files
-    if (pluginName && !ALWAYS_KEEP_PLUGINS.has(pluginName) && !ALWAYS_DISABLE_PLUGINS.has(pluginName)
-      && !PLUGIN_RULES_TO_DISABLE.has(pluginName) && !PLUGIN_PATTERNS_TO_DISABLE.has(pluginName)) {
-      // Unknown plugin - disable for CSS files
-      unknownPlugins.add(pluginName);
+    // 4. Unknown plugin - warn and add catch-all disable
+    if (pluginName) {
+      warn(`Unknown plugin '${pluginName}' detected in CSS config. Adding to always disable list.`);
+      ALWAYS_DISABLE_PLUGINS.add(pluginName);
       rulesToDisable.add(ruleName);
     }
   }
@@ -106,25 +327,37 @@ function analyzeConfigForJSRules(
 // Get all JavaScript-specific rules that should be disabled for CSS files
 function getJavaScriptRulesToDisable(): Record<string, 'off'> {
   const rulesToDisable = new Set<string>();
-  const unknownPlugins = new Set<string>();
 
-  // Configs to analyze
+  // 1. Process plugin rules directly
+  const plugins = [
+    { name: 'unicorn', plugin: unicornPlugin },
+    { name: '@stylistic', plugin: stylisticPlugin },
+  ];
+
+  for (const { name, plugin } of plugins) {
+    if (plugin.rules) {
+      // Create a fake config with all plugin rules enabled
+      const allRulesConfig = {
+        rules: Object.fromEntries(
+          Object.keys(plugin.rules).map(ruleName => [`${name}/${ruleName}`, 'error']),
+        ),
+      };
+      analyzeConfigForCSSRules(allRulesConfig, rulesToDisable);
+    }
+  }
+
+  // 2. Also analyze actual configs to catch core ESLint rules and any custom rules
   const configs = [
     eslintRecommended,
     unicornRecommended,
     stylisticRecommended,
     poupeUnicornRules,
     poupeStylisticRules,
+    poupeCssRules,
   ];
 
-  // Analyze each config
   for (const config of configs) {
-    analyzeConfigForJSRules(config, rulesToDisable, unknownPlugins);
-  }
-
-  // Warn about unknown plugins
-  if (unknownPlugins.size > 0) {
-    console.warn(`[@poupe/eslint-config] Unknown plugins detected in CSS config: ${[...unknownPlugins].join(', ')}. These rules will be disabled for CSS files.`);
+    analyzeConfigForCSSRules(config, rulesToDisable);
   }
 
   // Convert Set to object with 'off' values
@@ -162,10 +395,7 @@ export const cssRecommended: Linter.Config[] = [
     },
     rules: {
       ...cssConfigs.recommended.rules,
-      // Disable rules that conflict with Tailwind CSS v4 syntax
-      'css/no-invalid-at-rules': 'off',
-      // For now, disable parsing errors to allow Tailwind modifiers
-      'css/no-parsing-errors': 'off',
+      ...poupeCssRules,
     },
   },
   // Separate config to disable JavaScript rules for CSS files

--- a/src/configs/json.ts
+++ b/src/configs/json.ts
@@ -98,4 +98,12 @@ export const jsoncRecommended: Linter.Config[] = [
       ...poupePackageJsonRules,
     },
   },
+  {
+    name: 'jsonc/allow-comments',
+    files: ['**/.vscode/*.json'],
+    rules: {
+      // Allow comments in VSCode configuration files
+      'jsonc/no-comments': 'off',
+    },
+  },
 ];

--- a/src/configs/markdown.ts
+++ b/src/configs/markdown.ts
@@ -10,6 +10,7 @@ import markdownlintParser from 'eslint-plugin-markdownlint/parser.js';
 
 export const poupeMarkdownRules: Rules = {
   // Enforce stricter markdown formatting standards
+  'markdownlint/md007': ['error', { indent: 2 }], // Unordered list indentation - 2 spaces
   'markdownlint/md013': ['error', { line_length: 80 }], // Line length - 80 chars
   'markdownlint/md041': 'off', // First line in file should be a top level heading - disabled for flexibility
 };


### PR DESCRIPTION
## Summary

This PR implements a smart rule filtering system for CSS files that properly categorizes which ESLint rules should apply to CSS files vs JavaScript files.

## Problem

Previously, the CSS configuration was disabling ALL unicorn rules for CSS files by including 'unicorn' in `ALWAYS_DISABLE_PLUGINS`. This meant rules like `unicorn/filename-case` that make sense for any file type were incorrectly disabled for CSS files.

## Solution

Implemented a flexible rule filtering system that:
- Scans all plugin rules directly (not just configured ones) for complete coverage
- Supports per-plugin configuration with keep/disable rule sets
- Uses pattern-based matching for flexibility
- Has a dynamic warning system for unknown plugins/rules
- Strips plugin prefixes for cleaner configuration

## Changes

### Rule Categorization
- **Unicorn**: Keeps `filename-case` and `no-empty-file` (file-agnostic rules)
- **Stylistic**: Keeps basic formatting rules (`eol-last`, `no-trailing-spaces`, `no-multiple-empty-lines`, `no-mixed-spaces-and-tabs`, `spaced-comment`, `no-tabs`)
- Properly disables ~280 JavaScript-specific rules for CSS files

### New Export
- Added `poupeCssRules` export with Tailwind CSS v4 compatibility settings

### Documentation
- Updated AGENT.md with CSS configuration system details
- Updated README.md with CSS support information

## Test Plan

Tested the configuration to ensure:
- ✅ File-agnostic rules like `filename-case` still apply to CSS files
- ✅ Basic formatting rules work for CSS files
- ✅ JavaScript-specific rules are properly disabled
- ✅ Warning system catches unknown plugins/rules
- ✅ All plugin rules are scanned (not just configured ones)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced advanced CSS linting with support for Tailwind CSS v4, including a new rules configuration for CSS files.
  - Added intelligent filtering to apply relevant ESLint rules to CSS files, disabling JavaScript-specific rules and retaining important stylistic rules.
  - Enabled comments in VSCode JSON configuration files while maintaining strict no-comment enforcement for other JSON files.
  - Added a new markdownlint rule enforcing 2-space indentation for unordered lists.
- **Documentation**
  - Expanded documentation with detailed explanations of the CSS configuration system and guidance for extending CSS linting support.
  - Updated README with a new section describing CSS linting features and referencing further documentation.
- **Chores**
  - Bumped package version to 0.7.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->