### PR TITLE
feat(unicorn): allow numbers in all-caps MD filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.6] - 2025-06-29
+
+### Changed
+
+- **unicorn/filename-case**: Updated regex pattern to allow numbers in all-caps
+  markdown filenames (e.g., MD5.md, SHA256.md, RFC2119.md)
+
 ## [0.7.5] - 2025-06-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/eslint-config",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -46,9 +46,9 @@ export const poupeUnicornRules: Rules = {
     {
       case: 'kebabCase',
       ignore: [
-        // Allow all-caps .md files with - and _ delimiters
-        // (README.md, AGENT.md, PLAN.md, CODE_OF_CONDUCT.md, etc.)
-        String.raw`^[A-Z][A-Z\-_]*\.md$`,
+        // Allow all-caps .md files with numbers, - and _ delimiters
+        // (README.md, AGENT.md, PLAN.md, CODE_OF_CONDUCT.md, MD5.md, etc.)
+        String.raw`^[A-Z][A-Z0-9\-_]*\.md$`,
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- Updated the `unicorn/filename-case` rule to allow numbers in all-caps markdown filenames
- Changed regex pattern from `^[A-Z][A-Z\-_]*\.md$` to `^[A-Z][A-Z0-9\-_]*\.md$`
- This enables valid filenames like MD5.md, SHA256.md, or RFC2119.md

## Test plan
- [x] Run `pnpm build` to compile the package
- [x] Run `pnpm lint` to verify the configuration works correctly
- [x] All tests pass without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated filename validation to allow digits in all-caps `.md` filenames (e.g., `MD5.md` is now permitted).
  * Clarified comments to indicate support for numbers in such filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->