### PR TITLE
refactor: migrate to typescript-eslint config pattern & release v0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.7] - 2025-07-01
+
+### Changed
+
+- **Architecture refactor**: Migrated from `Linter.Config` to typescript-eslint's
+  `Config` type pattern with `withConfig()` helper for better type safety and
+  automatic config flattening
+- **CSS tolerant mode**: Enabled tolerant parsing mode for CSS files to support
+  Tailwind CSS v4 extended syntax without parsing errors
+
+### Updated
+
+- Updated @stylistic/eslint-plugin to v5
+- Updated @eslint/css to ^0.9.0
+- Updated typescript-eslint monorepo to ^8.35.0
+- Updated eslint monorepo to ^9.30.0
+- Updated pkg-pr-new to ^0.0.54
+
 ## [0.7.6] - 2025-06-29
 
 ### Changed

--- a/build.config.ts
+++ b/build.config.ts
@@ -1,7 +1,3 @@
 import { defineBuildConfig } from 'unbuild';
 
-export default defineBuildConfig({
-  externals: [
-    'eslint-flat-config-utils',
-  ],
-});
+export default defineBuildConfig({});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/eslint-config",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "@vitest/ui": "^3.2.4",
-    "eslint-flat-config-utils": "^2.1.0",
     "globals": "^16.2.0",
     "npm-run-all2": "^8.0.4",
     "pkg-pr-new": "^0.0.54",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
       '@vitest/ui':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
-      eslint-flat-config-utils:
-        specifier: ^2.1.0
-        version: 2.1.0
       globals:
         specifier: ^16.2.0
         version: 16.2.0

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,11 @@
 import {
   type Config,
+  type InfiniteDepthConfigWithExtends,
+
+  withConfig,
+} from './core';
+
+import {
   poupeConfigs,
 
   cssRecommended,
@@ -13,24 +19,26 @@ import {
   vueRecommended,
 } from './configs';
 
-import { config as withConfigs } from 'typescript-eslint';
+export { withConfig } from './core';
 
-export const defineConfig = (...userConfigs: Config[]): Config[] => withConfigs(
-  {
-    ignores: [
-      '**/dist',
-      '**/node_modules',
-    ],
-  },
-  eslintRecommended,
-  tseslintRecommended,
-  tsdocRecommended,
-  unicornRecommended,
-  stylisticRecommended,
-  markdownlintRecommended,
-  ...vueRecommended,
-  ...poupeConfigs,
-  ...cssRecommended, // CSS configs need to come after JS configs to override rules
-  ...jsoncRecommended, // Move JSON config after others to ensure it takes precedence
-  ...userConfigs,
-);
+export function defineConfig(...userConfigs: InfiniteDepthConfigWithExtends[]): Config[] {
+  return withConfig(
+    {
+      ignores: [
+        '**/dist',
+        '**/node_modules',
+      ],
+    },
+    eslintRecommended,
+    tseslintRecommended,
+    tsdocRecommended,
+    unicornRecommended,
+    stylisticRecommended,
+    markdownlintRecommended,
+    vueRecommended,
+    poupeConfigs,
+    cssRecommended, // CSS configs need to come after JS configs to override rules
+    jsoncRecommended, // Move JSON config after others to ensure it takes precedence
+    userConfigs,
+  );
+}

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -1,16 +1,15 @@
 import {
   type Config,
   type Rules,
+} from './core';
 
+import {
   poupeStylisticRules,
   poupeUnicornRules,
   poupeVueRules,
 } from './configs/index';
 
 export {
-  type Config,
-  type Rules,
-
   cssRecommended,
   eslintRecommended,
   jsoncRecommended,

--- a/src/configs/css.ts
+++ b/src/configs/css.ts
@@ -1,17 +1,22 @@
-import css from '@eslint/css';
+import css, { type CSSLanguageOptions } from '@eslint/css';
+
 import { tailwindSyntax } from '@eslint/css/syntax';
 import unicornPlugin from 'eslint-plugin-unicorn';
 import stylisticPlugin from '@stylistic/eslint-plugin';
 
-import type {
+import {
+  type Config,
+  type Rules,
   Linter,
-  Rules,
-} from '../core/types';
+  withConfig,
+} from '../core';
 
 import { tailwindV4Syntax } from './tailwind-v4-syntax';
 import { eslintRecommended } from './eslint';
 import { unicornRecommended, poupeUnicornRules } from './unicorn';
 import { stylisticRecommended, poupeStylisticRules } from './stylistic';
+
+type SyntaxConfig = NonNullable<CSSLanguageOptions['customSyntax']>;
 
 const { configs: cssConfigs } = css;
 
@@ -276,7 +281,7 @@ const KNOWN_PLUGINS = new Map<string, PluginRuleConfig>([
 
 // Analyze a config and process rules for CSS files
 function analyzeConfigForCSSRules(
-  config: Linter.Config | Record<string, unknown>,
+  config: Linter.Config | Config | Record<string, unknown>,
   rulesToDisable: Set<string>,
 ): void {
   const rules = 'rules' in config ? config.rules : config;
@@ -385,7 +390,7 @@ function getJavaScriptRulesToDisable(): Record<string, 'off'> {
 }
 
 // Merge the base tailwindSyntax with our v4 extensions
-const extendedTailwindSyntax = {
+const extendedTailwindSyntax: Partial<SyntaxConfig> = {
   ...tailwindSyntax,
   atrules: {
     ...tailwindSyntax.atrules,
@@ -393,7 +398,12 @@ const extendedTailwindSyntax = {
   },
 };
 
-export const cssRecommended: Linter.Config[] = [
+const languageOptions = {
+  tolerant: true, // Enable tolerant mode for Tailwind CSS compatibility
+  customSyntax: extendedTailwindSyntax,
+};
+
+export const cssRecommended: Config[] = withConfig(
   {
     name: 'poupe/css',
     files: ['**/*.css'],
@@ -401,13 +411,7 @@ export const cssRecommended: Linter.Config[] = [
       css,
     },
     language: 'css/css',
-    languageOptions: {
-      // Set tolerant mode to allow recoverable parsing errors
-      tolerant: true,
-      parserOptions: {
-        customSyntax: extendedTailwindSyntax,
-      },
-    },
+    languageOptions: languageOptions as Config['languageOptions'],
     rules: {
       ...cssConfigs.recommended.rules,
       ...poupeCssRules,
@@ -420,4 +424,4 @@ export const cssRecommended: Linter.Config[] = [
     files: ['**/*.css'],
     rules: getJavaScriptRulesToDisable(),
   },
-];
+);

--- a/src/configs/eslint.ts
+++ b/src/configs/eslint.ts
@@ -1,5 +1,5 @@
-import { Linter } from '../core/types';
+import { type Config } from '../core';
 
 import jsPlugin from '@eslint/js';
 
-export const eslintRecommended: Linter.Config = jsPlugin.configs.recommended;
+export const eslintRecommended: Config = jsPlugin.configs.recommended;

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,7 +1,7 @@
 export type {
   Config,
   Rules,
-} from '../core/types';
+} from '../core';
 
 export * from './css';
 export * from './eslint';

--- a/src/configs/json.ts
+++ b/src/configs/json.ts
@@ -1,7 +1,5 @@
-import type {
-  Linter,
-  Rules,
-} from '../core/types';
+import type { Config, Rules } from '../core';
+import { withConfig } from '../core';
 
 import jsoncPlugin from 'eslint-plugin-jsonc';
 import * as jsoncParser from 'jsonc-eslint-parser';
@@ -66,14 +64,13 @@ export const poupePackageJsonRules: Rules = {
   ],
 };
 
-export const jsoncRecommended: Linter.Config[] = [
+export const jsoncRecommended: Config[] = withConfig(
   {
     name: 'jsonc/json',
     files: ['**/*.json'],
     ignores: ['**/package.json'],
     plugins: {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      jsonc: jsoncPlugin as any,
+      jsonc: jsoncPlugin,
     },
     languageOptions: {
       parser: jsoncParser,
@@ -87,8 +84,7 @@ export const jsoncRecommended: Linter.Config[] = [
     name: 'jsonc/package-json',
     files: ['**/package.json'],
     plugins: {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      jsonc: jsoncPlugin as any,
+      jsonc: jsoncPlugin,
     },
     languageOptions: {
       parser: jsoncParser,
@@ -106,4 +102,4 @@ export const jsoncRecommended: Linter.Config[] = [
       'jsonc/no-comments': 'off',
     },
   },
-];
+);

--- a/src/configs/markdown.ts
+++ b/src/configs/markdown.ts
@@ -1,7 +1,7 @@
 import type {
-  Linter,
+  Config,
   Rules,
-} from '../core/types';
+} from '../core';
 
 // @ts-expect-error - no types available
 import markdownlintPlugin from 'eslint-plugin-markdownlint';
@@ -15,7 +15,7 @@ export const poupeMarkdownRules: Rules = {
   'markdownlint/md041': 'off', // First line in file should be a top level heading - disabled for flexibility
 };
 
-export const markdownlintRecommended: Linter.Config = {
+export const markdownlintRecommended: Config = {
   name: 'markdownlint/recommended',
   files: ['**/*.md'],
   plugins: {

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -1,6 +1,6 @@
 import type {
   Rules,
-} from '../core/types';
+} from '../core';
 
 import stylisticPlugin from '@stylistic/eslint-plugin';
 

--- a/src/configs/tailwind-v4-syntax.ts
+++ b/src/configs/tailwind-v4-syntax.ts
@@ -1,3 +1,7 @@
+import { type CSSLanguageOptions } from '@eslint/css';
+
+type SyntaxConfig = NonNullable<CSSLanguageOptions['customSyntax']>;
+
 /**
  * Extended Tailwind CSS v4 syntax for \@eslint/css
  *
@@ -9,7 +13,8 @@
  * - Custom variants created with \@custom-variant
  * - All Tailwind directives (\@theme, \@source, \@utility, etc.)
  */
-export const tailwindV4Syntax = {
+/* eslint-disable unicorn/no-null */
+export const tailwindV4Syntax: Partial<SyntaxConfig> = {
   atrules: {
     // @apply with support for any Tailwind utility including arbitrary variants
     'apply': {
@@ -22,7 +27,7 @@ export const tailwindV4Syntax = {
     },
     // @theme for defining design tokens
     'theme': {
-      prelude: undefined,
+      prelude: null,
       descriptors: {
         // CSS custom properties for design tokens
         '--*': '<any-value>',
@@ -71,3 +76,4 @@ export const tailwindV4Syntax = {
   // The properties option doesn't need to duplicate @apply
   // since it's already defined in atrules
 };
+/* eslint-enable unicorn/no-null */

--- a/src/configs/tsdoc.ts
+++ b/src/configs/tsdoc.ts
@@ -1,8 +1,8 @@
-import type { Linter, ESLint } from '../core/types';
+import type { Config, ESLint } from '../core';
 
 import tsdocPlugin from 'eslint-plugin-tsdoc';
 
-export const tsdocRecommended: Linter.Config = {
+export const tsdocRecommended: Config = {
   name: 'poupe/tsdoc-recommended',
   plugins: {
     tsdoc: tsdocPlugin as unknown as ESLint.Plugin,

--- a/src/configs/tseslint.ts
+++ b/src/configs/tseslint.ts
@@ -1,4 +1,4 @@
-import { Config } from '../core/types';
+import { Config } from '../core';
 
 import { configs } from 'typescript-eslint';
 

--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -1,13 +1,13 @@
 import type {
+  Config,
   Rules,
-  Linter,
-} from '../core/types';
+} from '../core';
 
 import unicornPlugin from 'eslint-plugin-unicorn';
 
 const { configs: unicornConfigs } = unicornPlugin;
 
-export const unicornRecommended: Linter.Config = unicornConfigs.recommended;
+export const unicornRecommended: Config = unicornConfigs.recommended;
 
 // unicorn/prevent-abbreviations
 const abbreviations = [

--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -1,7 +1,9 @@
-import type {
-  Rules,
-  Config,
-} from '../core/types';
+import {
+  type Rules,
+  type Config,
+
+  withConfig,
+} from '../core';
 
 import vuePlugin from 'eslint-plugin-vue';
 
@@ -25,7 +27,9 @@ function restrictVueRulesToVueFiles(config: Config): Config {
   };
 }
 
-export const vueRecommended: Config[] = vueConfigs['flat/recommended'].map(config => restrictVueRulesToVueFiles(config));
+export const vueRecommended: Config[] = withConfig(
+  vueConfigs['flat/recommended'].map(config => restrictVueRulesToVueFiles(config)),
+);
 
 export const poupeVueRules: Rules = {
   'vue/multi-word-component-names': 'off',

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,8 @@
 import { config as configFactory } from 'typescript-eslint';
 
+export { config as withConfig } from 'typescript-eslint';
+
+export type InfiniteDepthConfigWithExtends = Parameters<typeof configFactory>[number];
 export type Config = ReturnType<typeof configFactory>[number];
 export type Rules = Config['rules'] & {};
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,2 +1,2 @@
-export * from './types';
+export * from './config';
 export * from './utils';

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,4 +1,4 @@
-import { type Rules } from './types';
+import { type Rules } from './config';
 
 /**
  * Creates a new object by removing specified keys from the input object.

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,15 +1,15 @@
 import {
-  type Linter,
+  type Config,
+  type InfiniteDepthConfigWithExtends,
+
+  withConfig,
   withoutRules,
 } from './core/index';
 
 import {
-  type ResolvableFlatConfig,
-} from 'eslint-flat-config-utils';
-
-import {
   files,
   rules,
+
   // cssRecommended, // TODO: CSS support disabled - see sharedNuxtRules comment
   jsoncRecommended,
   markdownlintRecommended,
@@ -20,7 +20,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const { plugins: _unicornPlugins, ...unicornConfig } = unicornRecommended;
 
-const sharedNuxtRules: Linter.Config[] = [
+const sharedNuxtRules: InfiniteDepthConfigWithExtends = [
   // TODO: CSS support is temporarily disabled for Nuxt configurations
   // @nuxt/eslint-config (used by @nuxt/eslint) applies JavaScript/TypeScript
   // rules globally without file restrictions. Their regexp and @stylistic
@@ -38,15 +38,15 @@ const sharedNuxtRules: Linter.Config[] = [
     name: 'poupe/rules',
     rules,
   },
-  ...jsoncRecommended, // Move JSON config after others to ensure it takes precedence
+  jsoncRecommended, // Move JSON config after others to ensure it takes precedence
 ];
 
 /** rules for nuxt projects */
-export const forNuxt = (...userConfigs: Linter.Config[]): Linter.Config[] => [
+export const forNuxt = (...userConfigs: InfiniteDepthConfigWithExtends[]): Config[] => withConfig(
   unicornRecommended,
-  ...sharedNuxtRules,
-  ...userConfigs,
-];
+  sharedNuxtRules,
+  userConfigs,
+);
 
 /** rules for nuxt modules */
 const rulesForModules = withoutRules(unicornConfig.rules,
@@ -57,11 +57,11 @@ const rulesForModules = withoutRules(unicornConfig.rules,
   'unicorn/prefer-single-call',
 );
 
-export const forNuxtModules = (...userConfigs: ResolvableFlatConfig[]): ResolvableFlatConfig[] => [
+export const forNuxtModules = (...userConfigs: InfiniteDepthConfigWithExtends[]): Config[] => withConfig(
   {
     ...unicornConfig,
     rules: rulesForModules,
   },
-  ...sharedNuxtRules,
-  ...userConfigs,
-];
+  sharedNuxtRules,
+  userConfigs,
+);


### PR DESCRIPTION
## Summary

- Migrated from `Linter.Config` to typescript-eslint's `Config` type pattern for better type safety
- Implemented `withConfig()` helper for automatic config flattening and extends resolution
- Enabled CSS tolerant parsing mode to support Tailwind CSS v4 extended syntax
- Updated dependencies to latest versions

## Changes

### Architecture Refactoring
- Migrated all configuration files from ESLint's `Linter.Config` to typescript-eslint's `Config` type
- Now using `withConfig()` helper throughout for proper config composition
- Renamed `core/types.ts` to `core/config.ts` to better reflect its purpose
- All configs now properly typed as `Config[]` arrays

### CSS Improvements
- Enabled tolerant parsing mode for CSS files (`tolerant: true`)
- This allows parsing of Tailwind CSS v4 extended syntax without errors
- Properly typed CSS language options using `CSSLanguageOptions`

### Dependency Updates
- @stylistic/eslint-plugin: v5
- @eslint/css: ^0.9.0
- typescript-eslint monorepo: ^8.35.0
- eslint monorepo: ^9.30.0
- pkg-pr-new: ^0.0.54

## Test Plan

- [x] All tests pass (`pnpm test`)
- [x] Linting works correctly (`pnpm lint`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Build succeeds (`pnpm build`)
- [x] Example projects lint correctly