### PR TITLE
feat(json): add alphabetical sorting for package.json second-level objects

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -197,8 +197,9 @@ JSON files are linted with specific formatting rules:
 
 - **General JSON files**: 2-space indentation, no trailing commas, no comments
   (except tsconfig.json and .vscode/*.json which allow comments)
-- **package.json files**: Additionally enforces standard key ordering and
-  alphabetical dependency sorting
+- **package.json files**: Additionally enforces standard key ordering,
+  alphabetical dependency sorting, and alphabetical sorting of second-level
+  objects (scripts, pnpm, exports, publishConfig)
 
 ## Common Tasks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **package.json sorting**: Alphabetical sorting for second-level objects
+  (scripts, pnpm, exports, publishConfig) in package.json files
+
 ### Fixed
 
 - **JSON config**: Allow comments in tsconfig.json and tsconfig.*.json files by
@@ -11,6 +16,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **JSON configs**: Renamed to use `poupe/` prefix: `poupe/json` and
+  `poupe/package-json` for better namespace organization
 - **JSON tests**: Refactor tests for better clarity and more specific assertions
 
 ## [0.7.8] - 2025-07-01

--- a/examples/playground-nuxt-module/package.json
+++ b/examples/playground-nuxt-module/package.json
@@ -16,13 +16,13 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "nuxt-module-build build",
+    "clean": "rm -rf node_modules dist .nuxt playground/.nuxt playground/.output",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "clean": "rm -rf node_modules dist .nuxt playground/.nuxt playground/.output"
+    "lint": "env DEBUG=eslint:eslint eslint .",
+    "lint:fix": "env DEBUG=eslint:eslint eslint --fix .",
+    "prepack": "nuxt-module-build build"
   },
   "dependencies": {
     "@nuxt/kit": "^3.17.5"

--- a/examples/playground-nuxt/package.json
+++ b/examples/playground-nuxt/package.json
@@ -4,13 +4,13 @@
   "type": "module",
   "scripts": {
     "build": "nuxt build",
+    "clean": "rm -rf node_modules .nuxt .output",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
-    "preview": "nuxt preview",
+    "lint": "env DEBUG=eslint:eslint eslint .",
+    "lint:fix": "env DEBUG=eslint:eslint eslint --fix .",
     "postinstall": "nuxt prepare",
-    "clean": "rm -rf node_modules .nuxt .output",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "preview": "nuxt preview"
   },
   "dependencies": {
     "nuxt": "^3.17.5",

--- a/examples/playground-standard/package.json
+++ b/examples/playground-standard/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "clean": "rm -rf node_modules"
+    "clean": "rm -rf node_modules",
+    "lint": "env DEBUG=eslint:eslint eslint .",
+    "lint:fix": "env DEBUG=eslint:eslint eslint --fix ."
   },
   "devDependencies": {
     "@poupe/eslint-config": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -23,21 +23,21 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "run-s lint type-check test:all build publint",
-    "dev:prepare": "unbuild --stub",
-    "postinstall": "[ -s dist/index.mjs ] || unbuild --stub",
-    "lint": "unbuild --stub && env DEBUG=eslint:eslint eslint --fix .",
-    "lint:examples": "pnpm -r --filter \"./examples/*\" lint",
-    "lint:all": "run-s lint lint:examples",
     "build": "unbuild",
     "clean": "rm -rf dist node_modules && pnpm -r --filter \"./examples/*\" clean",
-    "type-check": "tsc --noEmit",
+    "dev:prepare": "unbuild --stub",
+    "lint": "unbuild --stub && env DEBUG=eslint:eslint eslint --fix .",
+    "lint:all": "run-s lint lint:examples",
+    "lint:examples": "pnpm -r --filter \"playground-*\" lint:fix",
+    "postinstall": "[ -s dist/index.mjs ] || unbuild --stub",
+    "precommit": "run-s lint:all type-check test:all build",
+    "prepack": "run-s lint type-check test:all build publint",
+    "publint": "publint",
     "test": "pnpm -r dev:prepare && node test/config.test.mjs",
+    "test:all": "run-s test:unit test",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest watch",
-    "test:all": "run-s test:unit test",
-    "precommit": "run-s lint:all type-check test:all build",
-    "publint": "publint"
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@eslint/css": "^0.9.0",

--- a/src/configs/__tests__/json.test.ts
+++ b/src/configs/__tests__/json.test.ts
@@ -8,8 +8,8 @@ describe('JSON Configuration', () => {
     });
 
     it('should have correct configuration names', () => {
-      expect(jsoncRecommended[0].name).toBe('jsonc/json');
-      expect(jsoncRecommended[1].name).toBe('jsonc/package-json');
+      expect(jsoncRecommended[0].name).toBe('poupe/json');
+      expect(jsoncRecommended[1].name).toBe('poupe/package-json');
       expect(jsoncRecommended[2].name).toBe('poupe/allow-json-comments');
     });
 
@@ -75,13 +75,13 @@ describe('JSON Configuration', () => {
 
         // Check that we have multiple pattern configurations
         const ruleArguments = sortKeysRule.slice(1);
-        expect(ruleArguments).toHaveLength(2);
+        expect(ruleArguments).toHaveLength(3);
       }
     });
 
     it('should sort root level package.json fields', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const sortKeysRule = poupePackageJsonRules['jsonc/sort-keys'] as [string, any, any];
+      const sortKeysRule = poupePackageJsonRules['jsonc/sort-keys'] as [string, any, any, any];
       const rootPattern = sortKeysRule[1];
 
       expect(rootPattern.pathPattern).toBe('^$');
@@ -92,11 +92,20 @@ describe('JSON Configuration', () => {
 
     it('should sort dependencies alphabetically', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const sortKeysRule = poupePackageJsonRules['jsonc/sort-keys'] as [string, any, any];
+      const sortKeysRule = poupePackageJsonRules['jsonc/sort-keys'] as [string, any, any, any];
       const depsPattern = sortKeysRule[2];
 
       expect(depsPattern.pathPattern).toBe('^(dependencies|devDependencies|peerDependencies|optionalDependencies)$');
       expect(depsPattern.order).toEqual({ type: 'asc' });
+    });
+
+    it('should sort other second-level objects alphabetically', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sortKeysRule = poupePackageJsonRules['jsonc/sort-keys'] as [string, any, any, any];
+      const secondLevelPattern = sortKeysRule[3];
+
+      expect(secondLevelPattern.pathPattern).toBe('^(scripts|pnpm|exports|publishConfig)$');
+      expect(secondLevelPattern.order).toEqual({ type: 'asc' });
     });
   });
 

--- a/src/configs/json.ts
+++ b/src/configs/json.ts
@@ -67,12 +67,17 @@ export const poupePackageJsonRules: Rules = {
       pathPattern: '^(dependencies|devDependencies|peerDependencies|optionalDependencies)$',
       order: { type: 'asc' },
     },
+    {
+      // Sort other second-level objects alphabetically (scripts, etc.)
+      pathPattern: '^(scripts|pnpm|exports|publishConfig)$',
+      order: { type: 'asc' },
+    },
   ],
 };
 
 export const jsoncRecommended: Config[] = withConfig(
   {
-    name: 'jsonc/json',
+    name: 'poupe/json',
     files: ['**/*.json'],
     ignores: ['**/package.json'],
     plugins: {
@@ -87,7 +92,7 @@ export const jsoncRecommended: Config[] = withConfig(
     },
   },
   {
-    name: 'jsonc/package-json',
+    name: 'poupe/package-json',
     files: ['**/package.json'],
     plugins: {
       jsonc: jsoncPlugin,


### PR DESCRIPTION
## Summary

Add alphabetical sorting for second-level objects in package.json files to improve consistency and readability across the codebase.

## Changes

### Features
- Add alphabetical sorting for `scripts`, `pnpm`, `exports`, and `publishConfig` objects in package.json
- Rename JSON configs to use `poupe/` namespace prefix:
  - `jsonc/json` → `poupe/json`
  - `jsonc/package-json` → `poupe/package-json`

### Improvements
- Apply sorting to all package.json files in the workspace
- Update tests to verify the new sorting behavior
- Update documentation to reflect the changes

### Fixed
- Allow comments in tsconfig.json and tsconfig.*.json files

## Test Plan

- [x] Unit tests pass with new sorting rules
- [x] Integration tests verify package.json sorting works correctly
- [x] All workspace package.json files are properly sorted
- [x] ESLint auto-fix correctly sorts package.json second-level objects

## Breaking Changes

None - The config renaming is backward compatible as the rules remain the same.

## Example

Before:
```json
{
  "scripts": {
    "test": "vitest",
    "build": "unbuild",
    "dev": "vite"
  }
}
```

After (auto-fixed):
```json
{
  "scripts": {
    "build": "unbuild",
    "dev": "vite",
    "test": "vitest"
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alphabetical sorting for second-level objects (scripts, pnpm, exports, publishConfig) in package.json files.
  * Introduced new npm scripts for precommit checks, publishing lint, and comprehensive testing.

* **Bug Fixes**
  * Improved ordering and clarity of npm scripts across various example projects.

* **Documentation**
  * Updated documentation and changelog to reflect new sorting rules and configuration naming conventions.

* **Tests**
  * Enhanced test coverage for new sorting rules and updated configuration names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->