### PR TITLE
feat: allow i, j, k as idiomatic variable names (v0.7.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.11] - 2025-07-02
+
 ### Changed
 
 - **unicorn/prevent-abbreviations**: Allow `i`, `j`, `k` as idiomatic variable names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **unicorn/prevent-abbreviations**: Allow `i`, `j`, `k` as idiomatic variable names
+  for loop counters and array indices
+
 ## [0.7.10] - 2025-07-02
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ custom rules:
 ### General JavaScript Rules
 
 * Enforces camelCase naming convention
+* Allows `i`, `j`, `k` as loop counters and array indices
 * Requires explicit radix in `parseInt`
 * Prevents console statements in production code
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/eslint-config",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "type": "module",
   "description": "Sharable ESLint configuration preset for Poupe UI projects with TypeScript, Vue.js, and Tailwind CSS support",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/src/configs/__tests__/unicorn.test.ts
+++ b/src/configs/__tests__/unicorn.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { poupeUnicornRules } from '../unicorn';
+
+interface PreventAbbreviationsOptions {
+  allowList: Record<string, boolean>
+  replacements: Record<string, boolean | string | string[]>
+}
+
+interface FilenameCaseOptions {
+  case: string
+  ignore?: string[]
+}
+
+describe('unicorn configuration', () => {
+  describe('prevent-abbreviations rule', () => {
+    it('should have correct configuration', () => {
+      const rule = poupeUnicornRules['unicorn/prevent-abbreviations'];
+      expect(rule).toBeDefined();
+      expect(Array.isArray(rule)).toBe(true);
+      if (Array.isArray(rule)) {
+        expect(rule[0]).toBe('error');
+      }
+    });
+
+    it('should allow i, j, k as variable names', () => {
+      const rule = poupeUnicornRules['unicorn/prevent-abbreviations'];
+      expect(Array.isArray(rule)).toBe(true);
+      if (Array.isArray(rule) && rule.length > 1) {
+        const options = rule[1] as PreventAbbreviationsOptions;
+        expect(options.allowList).toBeDefined();
+        expect(options.allowList.i).toBe(true);
+        expect(options.allowList.j).toBe(true);
+        expect(options.allowList.k).toBe(true);
+      }
+    });
+
+    it('should not suggest replacements for i, j, k', () => {
+      const rule = poupeUnicornRules['unicorn/prevent-abbreviations'];
+      expect(Array.isArray(rule)).toBe(true);
+      if (Array.isArray(rule) && rule.length > 1) {
+        const options = rule[1] as PreventAbbreviationsOptions;
+        expect(options.replacements).toBeDefined();
+        // i, j, k should not be in replacements object since they're in omitReplacementList
+        expect(options.replacements.i).toBeUndefined();
+        expect(options.replacements.j).toBeUndefined();
+        expect(options.replacements.k).toBeUndefined();
+      }
+    });
+
+    it('should allow other common abbreviations', () => {
+      const rule = poupeUnicornRules['unicorn/prevent-abbreviations'];
+      expect(Array.isArray(rule)).toBe(true);
+      if (Array.isArray(rule) && rule.length > 1) {
+        const options = rule[1] as PreventAbbreviationsOptions;
+        const commonAbbreviations = ['env', 'err', 'fn', 'pkg', 'props', 'utils'];
+
+        for (const abbr of commonAbbreviations) {
+          expect(options.allowList[abbr]).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe('filename-case rule', () => {
+    it('should enforce kebab-case with exceptions for uppercase markdown files', () => {
+      const rule = poupeUnicornRules['unicorn/filename-case'];
+      expect(rule).toBeDefined();
+      expect(Array.isArray(rule)).toBe(true);
+
+      if (Array.isArray(rule) && rule.length > 1) {
+        const severity = rule[0];
+        const options = rule[1] as FilenameCaseOptions;
+        expect(severity).toBe('error');
+        expect(options.case).toBe('kebabCase');
+        expect(options.ignore).toBeDefined();
+        expect(options.ignore?.[0]).toBe(String.raw`^[A-Z][A-Z0-9\-_]*\.md$`);
+      }
+    });
+  });
+});

--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -17,6 +17,8 @@ const abbreviations = [
   'err',
   'fn',
   'i',
+  'j',
+  'k',
   'msg',
   'opt',
   'opts',
@@ -29,7 +31,7 @@ const abbreviations = [
   'vars',
 ] as const;
 
-const omitReplacementList = new Set(['i']);
+const omitReplacementList = new Set(['i', 'j', 'k']);
 
 const allowList = Object.fromEntries(
   abbreviations.map(s => [s, true]),


### PR DESCRIPTION
## Summary

This PR allows `i`, `j`, and `k` as idiomatic variable names in the unicorn/prevent-abbreviations rule. These single-letter variables are commonly used as loop counters and array indices in mathematical and algorithmic contexts.

## Changes

- Added `j` and `k` to the abbreviations allow list (alongside existing `i`)
- Added `j` and `k` to the omitReplacementList to prevent replacement suggestions
- Added comprehensive tests for unicorn configuration
- Updated documentation in README and CHANGELOG

## Test Plan

- [x] Added unit tests for the unicorn configuration
- [x] Manually tested that `i`, `j`, `k` are allowed in loops and arrays
- [x] Verified other abbreviations still trigger the rule
- [x] All existing tests pass

## Example

```js
// ✅ Now allowed - no unicorn/prevent-abbreviations errors
for (let i = 0; i < 10; i++) {
  for (let j = 0; j < 10; j++) {
    for (let k = 0; k < 10; k++) {
      matrix[i][j][k] = i * j * k;
    }
  }
}

// ❌ Still errors - not in allow list
let e = new Error(); // suggests: error, event
let val = 42;        // suggests: value
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using the variable names `i`, `j`, and `k` as loop counters and array indices without triggering abbreviation warnings.

* **Documentation**
  * Updated the documentation and changelog to reflect the new rule allowing `i`, `j`, and `k` as exceptions for loop counters and array indices.

* **Tests**
  * Introduced new tests to verify the updated abbreviation rules and filename case enforcement.

* **Chores**
  * Bumped the package version to 0.7.11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->