### PR TITLE
fix: cross-platform playground examples (v0.7.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.12] - 2025-07-02
+
+### Fixed
+
+- **examples**: Use cross-platform compatible commands in playground scripts
+  - Replace Unix-specific `rm -rf` with `rimraf` for file deletion
+  - Replace Unix-specific `env` with `cross-env` for environment variables
+  - Ensures examples work correctly on Windows, macOS, and Linux
+
 ## [0.7.11] - 2025-07-02
 
 ### Changed

--- a/examples/playground-nuxt-module/package.json
+++ b/examples/playground-nuxt-module/package.json
@@ -16,12 +16,12 @@
     "dist"
   ],
   "scripts": {
-    "clean": "rm -rf node_modules dist .nuxt playground/.nuxt playground/.output",
+    "clean": "rimraf node_modules dist .nuxt playground/.nuxt playground/.output",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
-    "lint": "env DEBUG=eslint:eslint eslint .",
-    "lint:fix": "env DEBUG=eslint:eslint eslint --fix .",
+    "lint": "cross-env DEBUG=eslint:eslint eslint .",
+    "lint:fix": "cross-env DEBUG=eslint:eslint eslint --fix .",
     "prepack": "nuxt-module-build build"
   },
   "dependencies": {
@@ -34,6 +34,8 @@
     "@nuxt/module-builder": "latest",
     "@nuxt/test-utils": "latest",
     "@poupe/eslint-config": "workspace:*",
-    "nuxt": "latest"
+    "cross-env": "^7.0.3",
+    "nuxt": "latest",
+    "rimraf": "^6.0.1"
   }
 }

--- a/examples/playground-nuxt/package.json
+++ b/examples/playground-nuxt/package.json
@@ -4,11 +4,11 @@
   "type": "module",
   "scripts": {
     "build": "nuxt build",
-    "clean": "rm -rf node_modules .nuxt .output",
+    "clean": "rimraf node_modules .nuxt .output",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
-    "lint": "env DEBUG=eslint:eslint eslint .",
-    "lint:fix": "env DEBUG=eslint:eslint eslint --fix .",
+    "lint": "cross-env DEBUG=eslint:eslint eslint .",
+    "lint:fix": "cross-env DEBUG=eslint:eslint eslint --fix .",
     "postinstall": "nuxt prepare",
     "preview": "nuxt preview"
   },
@@ -19,6 +19,8 @@
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.4.1",
-    "@poupe/eslint-config": "workspace:*"
+    "@poupe/eslint-config": "workspace:*",
+    "cross-env": "^7.0.3",
+    "rimraf": "^6.0.1"
   }
 }

--- a/examples/playground-standard/package.json
+++ b/examples/playground-standard/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "clean": "rm -rf node_modules",
-    "lint": "env DEBUG=eslint:eslint eslint .",
-    "lint:fix": "env DEBUG=eslint:eslint eslint --fix ."
+    "clean": "rimraf node_modules",
+    "lint": "cross-env DEBUG=eslint:eslint eslint .",
+    "lint:fix": "cross-env DEBUG=eslint:eslint eslint --fix ."
   },
   "devDependencies": {
     "@poupe/eslint-config": "workspace:*",
-    "eslint": "^9.27.0"
+    "cross-env": "^7.0.3",
+    "eslint": "^9.30.1",
+    "rimraf": "^6.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/eslint-config",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "type": "module",
   "description": "Sharable ESLint configuration preset for Poupe UI projects with TypeScript, Vue.js, and Tailwind CSS support",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,12 @@ importers:
       '@poupe/eslint-config':
         specifier: workspace:*
         version: link:../..
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
 
   examples/playground-nuxt-module:
     dependencies:
@@ -131,18 +137,30 @@ importers:
       '@poupe/eslint-config':
         specifier: workspace:*
         version: link:../..
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       nuxt:
         specifier: latest
         version: 3.17.6(@parcel/watcher@2.5.1)(@types/node@24.0.3)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.30.1(jiti@2.4.2))(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.44.0)(terser@5.43.1)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
 
   examples/playground-standard:
     devDependencies:
       '@poupe/eslint-config':
         specifier: workspace:*
         version: link:../..
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       eslint:
-        specifier: ^9.27.0
+        specifier: ^9.30.1
         version: 9.30.1(jiti@2.4.2)
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
 
 packages:
 


### PR DESCRIPTION
## Summary

- Make example projects work on all platforms by using cross-platform tools
- Fix scripts that only work on Unix-like systems (macOS/Linux)

## Changes

### Cross-platform tools
- Replace `rm -rf` with `rimraf` for file deletion
- Replace `env` with `cross-env` for setting environment variables

### Affected files
- `examples/playground-standard/package.json`
- `examples/playground-nuxt/package.json`
- `examples/playground-nuxt-module/package.json`

## Why this matters

Developers on Windows couldn't run the example projects due to Unix-specific commands. This fix ensures all developers can use the examples regardless of their operating system.

## Test plan

- [x] Verified scripts work on Unix-like systems
- [ ] Test on Windows to confirm cross-platform compatibility
- [x] All dependencies properly added to devDependencies
- [x] No breaking changes to existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated example playground scripts to use cross-platform compatible commands, ensuring proper functionality on Windows, macOS, and Linux.
  * Replaced Unix-specific commands with `rimraf` for file deletion and `cross-env` for setting environment variables in example projects.

* **Chores**
  * Bumped version to 0.7.12.
  * Added `cross-env` and `rimraf` as development dependencies in example projects.
  * Updated changelog to reflect recent fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->