### PR TITLE
refactor: restructure configs and enhance Nuxt support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **core/globs**: New module exporting common file pattern constants
+  (`GLOB_CSS`, `GLOB_SRC`, `GLOB_VUE`, etc.)
+
 ### Changed
 
 - **perfectionist**: Enhanced import sorting configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,22 @@ All notable changes to this project will be documented in this file.
   (`GLOB_CSS`, `GLOB_SRC`, `GLOB_VUE`, etc.)
 - **unicorn**: Split into `poupeUnicornConfigs` array with separate filename
   and general rules
+- **unicorn**: Added `unicornSetupConfig` export for bare plugin setup without
+  rules
 - **vue**: Added `vueSetupConfig` for Vue TypeScript parser configuration
+
+### Fixed
+
+- **nuxt**: Fixed unicorn plugin resolution for Nuxt modules by adding
+  `unicornSetupConfig` to ensure plugin availability when rules are referenced
 
 ### Internal
 
 - Refactored test files to work with new config structure
 - Simplified `forNuxtModules` to map over `forNuxt` results instead of
   duplicating logic
+- Updated `@nuxt/eslint` to v1.5.1 in playground examples
+- Updated `@vue/eslint-config-typescript` to v14.6.0
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.13] - 2025-07-03
+
 ### Added
 
 - **core/globs**: New module exporting common file pattern constants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project will be documented in this file.
 
 - **core/globs**: New module exporting common file pattern constants
   (`GLOB_CSS`, `GLOB_SRC`, `GLOB_VUE`, etc.)
+- **unicorn**: Split into `poupeUnicornConfigs` array with separate filename
+  and general rules
+- **vue**: Added `vueSetupConfig` for Vue TypeScript parser configuration
+
+### Internal
+
+- Refactored test files to work with new config structure
+- Simplified `forNuxtModules` to map over `forNuxt` results instead of
+  duplicating logic
 
 ### Changed
 
@@ -15,6 +24,12 @@ All notable changes to this project will be documented in this file.
   - Enabled `partitionByNewLine` for `sort-imports` and `sort-named-imports`
   - Changed `newlinesBetween` from 'always' to 'ignore' to avoid conflicts
   - Empty lines now act as block separators, allowing logical grouping of imports
+- **configs**: Restructured configuration exports from rule-only exports to
+  complete ESLint config objects
+  - Each config now includes its own file patterns for better modularity
+  - Renamed exports for clarity (e.g., `cssRecommended` → `poupeCSSConfig`)
+  - Added centralized glob constants in `core/globs.ts`
+- **stylistic**: Extended stylistic rules to apply to Vue files
 
 ## [0.7.12] - 2025-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **perfectionist**: Enhanced import sorting configuration
+  - Enabled `partitionByNewLine` for `sort-imports` and `sort-named-imports`
+  - Changed `newlinesBetween` from 'always' to 'ignore' to avoid conflicts
+  - Empty lines now act as block separators, allowing logical grouping of imports
+
 ## [0.7.12] - 2025-07-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -140,6 +140,28 @@ import { Button } from './components/Button';
 import { useEffect, useState } from 'react';
 ```
 
+#### Import Grouping with Empty Lines
+
+The configuration respects empty lines as block separators, allowing you to
+organize imports into logical groups:
+
+```js
+// Core React imports
+import React from 'react';
+import { useState, useEffect } from 'react';
+
+// External libraries
+import axios from 'axios';
+import { z } from 'zod';
+
+// Internal modules
+import { config } from './config';
+import { Button } from './components/Button';
+```
+
+Each group separated by empty lines is sorted independently, preserving your
+intended organization while maintaining consistent ordering within each group.
+
 ### Union Type Sorting
 
 The configuration also includes automatic sorting of TypeScript union types with

--- a/examples/playground-nuxt-module/package.json
+++ b/examples/playground-nuxt-module/package.json
@@ -29,8 +29,8 @@
   },
   "devDependencies": {
     "@nuxt/devtools": "latest",
-    "@nuxt/eslint": "^1.4.1",
-    "@nuxt/eslint-config": "^1.4.1",
+    "@nuxt/eslint": "^1.5.1",
+    "@nuxt/eslint-config": "^1.5.1",
     "@nuxt/module-builder": "latest",
     "@nuxt/test-utils": "latest",
     "@poupe/eslint-config": "workspace:*",

--- a/examples/playground-nuxt/package.json
+++ b/examples/playground-nuxt/package.json
@@ -18,7 +18,7 @@
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
-    "@nuxt/eslint": "^1.4.1",
+    "@nuxt/eslint": "^1.5.1",
     "@poupe/eslint-config": "workspace:*",
     "cross-env": "^7.0.3",
     "rimraf": "^6.0.1"

--- a/examples/playground-nuxt/test.ts
+++ b/examples/playground-nuxt/test.ts
@@ -1,0 +1,6 @@
+// Test file for TypeScript linting
+export function testFunction(props: { env: string }) {
+  const array = [1, 2, 3];
+  for (const item of array) console.log(item);
+  return props.env;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/eslint-config",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "type": "module",
   "description": "Sharable ESLint configuration preset for Poupe UI projects with TypeScript, Vue.js, and Tailwind CSS support",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@humanwhocodes/momoa": "^3.3.8",
     "@stylistic/eslint-plugin": "^5.1.0",
     "@typescript-eslint/parser": "^8.35.1",
-    "@vue/eslint-config-typescript": "^14.5.1",
+    "@vue/eslint-config-typescript": "^14.6.0",
     "eslint": "^9.30.1",
     "eslint-plugin-jsonc": "^2.20.1",
     "eslint-plugin-markdownlint": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^8.35.1
         version: 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       '@vue/eslint-config-typescript':
-        specifier: ^14.5.1
-        version: 14.5.1(eslint-plugin-vue@10.2.0(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.1.3(eslint@9.30.1(jiti@2.4.2))))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+        specifier: ^14.6.0
+        version: 14.6.0(eslint-plugin-vue@10.3.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.2.0(eslint@9.30.1(jiti@2.4.2))))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       eslint:
         specifier: ^9.30.1
         version: 9.30.1(jiti@2.4.2)
@@ -49,7 +49,7 @@ importers:
         version: 59.0.1(eslint@9.30.1(jiti@2.4.2))
       eslint-plugin-vue:
         specifier: ^10.2.0
-        version: 10.2.0(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.1.3(eslint@9.30.1(jiti@2.4.2)))
+        version: 10.3.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.2.0(eslint@9.30.1(jiti@2.4.2)))
       jsonc-eslint-parser:
         specifier: ^2.4.0
         version: 2.4.0
@@ -101,8 +101,8 @@ importers:
         version: 4.5.1(vue@3.5.17(typescript@5.8.3))
     devDependencies:
       '@nuxt/eslint':
-        specifier: ^1.4.1
-        version: 1.4.1(@typescript-eslint/utils@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))
+        specifier: ^1.5.1
+        version: 1.5.1(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))
       '@poupe/eslint-config':
         specifier: workspace:*
         version: link:../..
@@ -123,11 +123,11 @@ importers:
         specifier: latest
         version: 2.6.2(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
       '@nuxt/eslint':
-        specifier: ^1.4.1
-        version: 1.4.1(@typescript-eslint/utils@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))
+        specifier: ^1.5.1
+        version: 1.5.1(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))
       '@nuxt/eslint-config':
-        specifier: ^1.4.1
-        version: 1.4.1(@typescript-eslint/utils@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+        specifier: ^1.5.1
+        version: 1.5.1(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       '@nuxt/module-builder':
         specifier: latest
         version: 1.0.1(@nuxt/cli@3.25.1(magicast@0.3.5))(@vue/compiler-core@3.5.17)(esbuild@0.25.5)(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))
@@ -292,11 +292,11 @@ packages:
     resolution: {integrity: sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==}
     engines: {node: '>=6.9.0'}
 
-  '@clack/core@0.4.2':
-    resolution: {integrity: sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg==}
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
 
-  '@clack/prompts@0.10.1':
-    resolution: {integrity: sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw==}
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@cloudflare/kv-asset-handler@0.4.0':
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
@@ -322,9 +322,9 @@ packages:
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
-  '@es-joy/jsdoccomment@0.50.2':
-    resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
-    engines: {node: '>=18'}
+  '@es-joy/jsdoccomment@0.52.0':
+    resolution: {integrity: sha512-BXuN7BII+8AyNtn57euU2Yxo9yA/KUDNzrpXyi3pfqKmBhhysR6ZWOebFh3vyPoqA3/j1SOvGgucElMGwlXing==}
+    engines: {node: '>=20.11.0'}
 
   '@esbuild/aix-ppc64@0.25.5':
     resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
@@ -722,8 +722,8 @@ packages:
     peerDependencies:
       vite: '>=6.0'
 
-  '@nuxt/eslint-config@1.4.1':
-    resolution: {integrity: sha512-ubVHUZlOAJsSlnHWI3TO0b1w6sz7sS5wjQyslO98rgxjqbaI7yw6aIB3loQrjiSAS0jxzfzZTnXxC6ysPkXqvw==}
+  '@nuxt/eslint-config@1.5.1':
+    resolution: {integrity: sha512-4XmczqZcBB88tGrNVj+UwPe9R8fvKtYcv3QCb43GZj6rNLysIY6oNvtkBCoWQvNmL7eUvEjjQOluuVqpOyAB2Q==}
     peerDependencies:
       eslint: ^9.0.0
       eslint-plugin-format: '*'
@@ -731,13 +731,13 @@ packages:
       eslint-plugin-format:
         optional: true
 
-  '@nuxt/eslint-plugin@1.4.1':
-    resolution: {integrity: sha512-1d/1GjQBlk7naGrq+ipvWj2CJkIMrM6BkIXIkRo+v1ohx8reQE7sU2SFnxN4HtQGZefSuwriudcUp4ABeXdYTQ==}
+  '@nuxt/eslint-plugin@1.5.1':
+    resolution: {integrity: sha512-k5WjMDN49jWMb997fu6fGcB3zTLxCoy7eyowe/lCwPHpXU8v+HvVu84e7Tgw0WhUPxLzZPpikoGJXqHH/u88Fw==}
     peerDependencies:
       eslint: ^9.0.0
 
-  '@nuxt/eslint@1.4.1':
-    resolution: {integrity: sha512-4clrizd+NnO/mLlBH/2or17Zn0rQ6QFmhEng0S3DVq3LAS+gltV3FXDO1ZAoAvuncMZJtAgoSTh8XWfiGoXCBA==}
+  '@nuxt/eslint@1.5.1':
+    resolution: {integrity: sha512-YIOHCufsl/6w0LCQHM8sprcHz9WDx2N79clMYNfGF1SqBgrhNgYyu2PByU9eGfuXpVxDEMo6D419a5Ct730oZQ==}
     peerDependencies:
       eslint: ^9.0.0
       eslint-webpack-plugin: ^4.1.0
@@ -1253,12 +1253,6 @@ packages:
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
 
-  '@stylistic/eslint-plugin@4.4.1':
-    resolution: {integrity: sha512-CEigAk7eOLyHvdgmpZsKFwtiqS2wFwI1fn4j09IU9GmD4euFM4jEBAViWeCqaNLlbX2k2+A/Fq9cje4HQBXuJQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: '>=9.0.0'
-
   '@stylistic/eslint-plugin@5.1.0':
     resolution: {integrity: sha512-TJRJul4u/lmry5N/kyCU+7RWWOk0wyXN+BncRlDYBqpLFnzXkd7QGVfN7KewarFIXv0IX0jSF/Ksu7aHWEDeuw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1379,101 +1373,6 @@ packages:
     peerDependencies:
       vue: '>=3.5.13'
 
-  '@unrs/resolver-binding-android-arm-eabi@1.9.0':
-    resolution: {integrity: sha512-h1T2c2Di49ekF2TE8ZCoJkb+jwETKUIPDJ/nO3tJBKlLFPu+fyd93f0rGP/BvArKx2k2HlRM4kqkNarj3dvZlg==}
-    cpu: [arm]
-    os: [android]
-
-  '@unrs/resolver-binding-android-arm64@1.9.0':
-    resolution: {integrity: sha512-sG1NHtgXtX8owEkJ11yn34vt0Xqzi3k9TJ8zppDmyG8GZV4kVWw44FHwKwHeEFl07uKPeC4ZoyuQaGh5ruJYPA==}
-    cpu: [arm64]
-    os: [android]
-
-  '@unrs/resolver-binding-darwin-arm64@1.9.0':
-    resolution: {integrity: sha512-nJ9z47kfFnCxN1z/oYZS7HSNsFh43y2asePzTEZpEvK7kGyuShSl3RRXnm/1QaqFL+iP+BjMwuB+DYUymOkA5A==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@unrs/resolver-binding-darwin-x64@1.9.0':
-    resolution: {integrity: sha512-TK+UA1TTa0qS53rjWn7cVlEKVGz2B6JYe0C++TdQjvWYIyx83ruwh0wd4LRxYBM5HeuAzXcylA9BH2trARXJTw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@unrs/resolver-binding-freebsd-x64@1.9.0':
-    resolution: {integrity: sha512-6uZwzMRFcD7CcCd0vz3Hp+9qIL2jseE/bx3ZjaLwn8t714nYGwiE84WpaMCYjU+IQET8Vu/+BNAGtYD7BG/0yA==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@unrs/resolver-binding-linux-arm-gnueabihf@1.9.0':
-    resolution: {integrity: sha512-bPUBksQfrgcfv2+mm+AZinaKq8LCFvt5PThYqRotqSuuZK1TVKkhbVMS/jvSRfYl7jr3AoZLYbDkItxgqMKRkg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-arm-musleabihf@1.9.0':
-    resolution: {integrity: sha512-uT6E7UBIrTdCsFQ+y0tQd3g5oudmrS/hds5pbU3h4s2t/1vsGWbbSKhBSCD9mcqaqkBwoqlECpUrRJCmldl8PA==}
-    cpu: [arm]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-arm64-gnu@1.9.0':
-    resolution: {integrity: sha512-vdqBh911wc5awE2bX2zx3eflbyv8U9xbE/jVKAm425eRoOVv/VseGZsqi3A3SykckSpF4wSROkbQPvbQFn8EsA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-arm64-musl@1.9.0':
-    resolution: {integrity: sha512-/8JFZ/SnuDr1lLEVsxsuVwrsGquTvT51RZGvyDB/dOK3oYK2UqeXzgeyq6Otp8FZXQcEYqJwxb9v+gtdXn03eQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-ppc64-gnu@1.9.0':
-    resolution: {integrity: sha512-FkJjybtrl+rajTw4loI3L6YqSOpeZfDls4SstL/5lsP2bka9TiHUjgMBjygeZEis1oC8LfJTS8FSgpKPaQx2tQ==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-riscv64-gnu@1.9.0':
-    resolution: {integrity: sha512-w/NZfHNeDusbqSZ8r/hp8iL4S39h4+vQMc9/vvzuIKMWKppyUGKm3IST0Qv0aOZ1rzIbl9SrDeIqK86ZpUK37w==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-riscv64-musl@1.9.0':
-    resolution: {integrity: sha512-bEPBosut8/8KQbUixPry8zg/fOzVOWyvwzOfz0C0Rw6dp+wIBseyiHKjkcSyZKv/98edrbMknBaMNJfA/UEdqw==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-s390x-gnu@1.9.0':
-    resolution: {integrity: sha512-LDtMT7moE3gK753gG4pc31AAqGUC86j3AplaFusc717EUGF9ZFJ356sdQzzZzkBk1XzMdxFyZ4f/i35NKM/lFA==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-x64-gnu@1.9.0':
-    resolution: {integrity: sha512-WmFd5KINHIXj8o1mPaT8QRjA9HgSXhN1gl9Da4IZihARihEnOylu4co7i/yeaIpcfsI6sYs33cNZKyHYDh0lrA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@unrs/resolver-binding-linux-x64-musl@1.9.0':
-    resolution: {integrity: sha512-CYuXbANW+WgzVRIl8/QvZmDaZxrqvOldOwlbUjIM4pQ46FJ0W5cinJ/Ghwa/Ng1ZPMJMk1VFdsD/XwmCGIXBWg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@unrs/resolver-binding-wasm32-wasi@1.9.0':
-    resolution: {integrity: sha512-6Rp2WH0OoitMYR57Z6VE8Y6corX8C6QEMWLgOV6qXiJIeZ1F9WGXY/yQ8yDC4iTraotyLOeJ2Asea0urWj2fKQ==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@unrs/resolver-binding-win32-arm64-msvc@1.9.0':
-    resolution: {integrity: sha512-rknkrTRuvujprrbPmGeHi8wYWxmNVlBoNW8+4XF2hXUnASOjmuC9FNF1tGbDiRQWn264q9U/oGtixyO3BT8adQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@unrs/resolver-binding-win32-ia32-msvc@1.9.0':
-    resolution: {integrity: sha512-Ceymm+iBl+bgAICtgiHyMLz6hjxmLJKqBim8tDzpX61wpZOx2bPK6Gjuor7I2RiUynVjvvkoRIkrPyMwzBzF3A==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@unrs/resolver-binding-win32-x64-msvc@1.9.0':
-    resolution: {integrity: sha512-k59o9ZyeyS0hAlcaKFezYSH2agQeRFEB7KoQLXl3Nb3rgkqT1NY9Vwy+SqODiLmYnEjxWJVRE/yq2jFVqdIxZw==}
-    cpu: [x64]
-    os: [win32]
-
   '@vercel/nft@0.29.4':
     resolution: {integrity: sha512-6lLqMNX3TuycBPABycx7A9F1bHQR7kiQln6abjFbPrf5C/05qHM9M5E4PeTE59c7z8g6vHnx1Ioihb2AQl7BTA==}
     engines: {node: '>=18'}
@@ -1578,8 +1477,8 @@ packages:
   '@vue/devtools-shared@7.7.7':
     resolution: {integrity: sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw==}
 
-  '@vue/eslint-config-typescript@14.5.1':
-    resolution: {integrity: sha512-ys6qdYHGXS/WLt0r5vUcTiG163F4NbNpx3ABTsGITw8k5uCFiv4g9E1N9Jydlw62KzJMVKGcpXbg6LCA3fV+eA==}
+  '@vue/eslint-config-typescript@14.6.0':
+    resolution: {integrity: sha512-UpiRY/7go4Yps4mYCjkvlIbVWmn9YvPGQDxTAlcKLphyaD77LjIu3plH4Y9zNT0GB4f3K5tMmhhtRhPOgrQ/bQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^9.10.0
@@ -2351,15 +2250,6 @@ packages:
   eslint-flat-config-utils@2.1.0:
     resolution: {integrity: sha512-6fjOJ9tS0k28ketkUcQ+kKptB4dBZY2VijMZ9rGn8Cwnn1SH0cZBoPXT8AHBFHxmHcLFQK9zbELDinZ2Mr1rng==}
 
-  eslint-import-context@0.1.8:
-    resolution: {integrity: sha512-bq+F7nyc65sKpZGT09dY0S0QrOnQtuDVIfyTGQ8uuvtMIF7oHp6CEP3mouN0rrnYF3Jqo6Ke0BfU/5wASZue1w==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      unrs-resolver: ^1.0.0
-    peerDependenciesMeta:
-      unrs-resolver:
-        optional: true
-
   eslint-json-compat-utils@0.2.1:
     resolution: {integrity: sha512-YzEodbDyW8DX8bImKhAcCeu/L31Dd/70Bidx2Qex9OFUtgzXLqtfWL4Hr5fM/aCCB8QUZLuJur0S9k6UfgFkfg==}
     engines: {node: '>=12'}
@@ -2376,22 +2266,19 @@ packages:
     peerDependencies:
       eslint: '*'
 
-  eslint-plugin-import-x@4.15.2:
-    resolution: {integrity: sha512-J5gx7sN6DTm0LRT//eP3rVVQ2Yi4hrX0B+DbWxa5er8PZ6JjLo9GUBwogIFvEDdwJaSqZplpQT+haK/cXhb7VQ==}
+  eslint-plugin-import-lite@0.3.0:
+    resolution: {integrity: sha512-dkNBAL6jcoCsXZsQ/Tt2yXmMDoNt5NaBh/U7yvccjiK8cai6Ay+MK77bMykmqQA2bTF6lngaLCDij6MTO3KkvA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/utils': ^8.0.0
-      eslint: ^8.57.0 || ^9.0.0
-      eslint-import-resolver-node: '*'
+      eslint: '>=9.0.0'
+      typescript: '>=4.5'
     peerDependenciesMeta:
-      '@typescript-eslint/utils':
-        optional: true
-      eslint-import-resolver-node:
+      typescript:
         optional: true
 
-  eslint-plugin-jsdoc@50.8.0:
-    resolution: {integrity: sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==}
-    engines: {node: '>=18'}
+  eslint-plugin-jsdoc@51.3.3:
+    resolution: {integrity: sha512-8XK/9wncTh4PPntQfM4iYJ2v/kvX4qsfBzp+dTnyxpERWhl2R9hEJw1ihws+yAecg9CC6ExTfMInEg3wSK9kWA==}
+    engines: {node: '>=20.11.0'}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
 
@@ -2428,12 +2315,16 @@ packages:
     peerDependencies:
       eslint: '>=9.22.0'
 
-  eslint-plugin-vue@10.2.0:
-    resolution: {integrity: sha512-tl9s+KN3z0hN2b8fV2xSs5ytGl7Esk1oSCxULLwFcdaElhZ8btYYZFrWxvh4En+czrSDtuLCeCOGa8HhEZuBdQ==}
+  eslint-plugin-vue@10.3.0:
+    resolution: {integrity: sha512-A0u9snqjCfYaPnqqOaH6MBLVWDUIN4trXn8J3x67uDcXvR7X6Ut8p16N+nYhMCQ9Y7edg2BIRGzfyZsY0IdqoQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
+      '@typescript-eslint/parser': ^7.0.0 || ^8.0.0
       eslint: ^8.57.0 || ^9.0.0
       vue-eslint-parser: ^10.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
 
   eslint-processor-vue-blocks@2.0.0:
     resolution: {integrity: sha512-u4W0CJwGoWY3bjXAuFpc/b6eK3NQEI8MoeW7ritKj3G3z/WtHrKjkqf+wk8mPEy5rlMGS+k6AZYOw2XBoN/02Q==}
@@ -2445,8 +2336,8 @@ packages:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint-typegen@2.2.0:
-    resolution: {integrity: sha512-OVgibKnRNnlSs4MhMz8uTRLSSIsvTXjH7a1gzXvyDIVU/txX1t8Zr9I/vOSwWIhtACX5DCPLo9CuyvA9usyjyw==}
+  eslint-typegen@2.2.1:
+    resolution: {integrity: sha512-DMx6fMxSsou1wiT2dviHvKRevCx6O7axogtl2WE0Pjq/p2D3rAx9ubsmQWMTmYyT/vmBWZ1yxZyAXhx1u7QpiA==}
     peerDependencies:
       eslint: ^9.0.0
 
@@ -2682,9 +2573,6 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
-
-  get-tsconfig@4.10.1:
-    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
@@ -3409,11 +3297,6 @@ packages:
   nanotar@0.2.0:
     resolution: {integrity: sha512-9ca1h0Xjvo9bEkE4UOxgAzLV0jHKe6LMaxo37ND2DAhhAtd0j8pR1Wxz+/goMrZO8AEZTWCmyaOsFI/W5AdpCQ==}
 
-  napi-postinstall@0.2.4:
-    resolution: {integrity: sha512-ZEzHJwBhZ8qQSbknHqYcdtQVr8zUgGyM/q6h6qAyhtyVMNrSgDhrC4disf03dYW0e+czXyLnZINnCTEkWy0eJg==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-    hasBin: true
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -4073,9 +3956,6 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
@@ -4268,10 +4148,6 @@ packages:
   split-on-first@3.0.0:
     resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
     engines: {node: '>=12'}
-
-  stable-hash-x@0.1.1:
-    resolution: {integrity: sha512-l0x1D6vhnsNUGPFVDx45eif0y6eedVC8nm5uACTrVFJFtl2mLRW17aWtVyxFCpn5t94VUPkjU8vSLwIuwwqtJQ==}
-    engines: {node: '>=12.0.0'}
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
@@ -4577,9 +4453,6 @@ packages:
     resolution: {integrity: sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==}
     engines: {node: '>=18.12.0'}
 
-  unrs-resolver@1.9.0:
-    resolution: {integrity: sha512-wqaRu4UnzBD2ABTC1kLfBjAqIDZ5YUTr/MLGa7By47JV1bJDSW7jq/ZSLigB7enLe7ubNaJhtnBXgrc/50cEhg==}
-
   unstorage@1.16.0:
     resolution: {integrity: sha512-WQ37/H5A7LcRPWfYOrDa1Ys02xAbpPJq6q5GkO88FBXVSQzHd7+BjEwfRqyaSWCv9MbsJy058GWjjPjcJ16GGA==}
     peerDependencies:
@@ -4831,8 +4704,8 @@ packages:
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
 
-  vue-eslint-parser@10.1.3:
-    resolution: {integrity: sha512-dbCBnd2e02dYWsXoqX5yKUZlOt+ExIpq7hmHKPb5ZqKcjf++Eo0hMseFTZMLKThrUk61m+Uv6A2YSBve6ZvuDQ==}
+  vue-eslint-parser@10.2.0:
+    resolution: {integrity: sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -5171,14 +5044,14 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@clack/core@0.4.2':
+  '@clack/core@0.5.0':
     dependencies:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.10.1':
+  '@clack/prompts@0.11.0':
     dependencies:
-      '@clack/core': 0.4.2
+      '@clack/core': 0.5.0
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
@@ -5215,7 +5088,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@es-joy/jsdoccomment@0.50.2':
+  '@es-joy/jsdoccomment@0.52.0':
     dependencies:
       '@types/estree': 1.0.8
       '@typescript-eslint/types': 8.35.1
@@ -5698,37 +5571,35 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/eslint-config@1.4.1(@typescript-eslint/utils@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
+  '@nuxt/eslint-config@1.5.1(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
-      '@clack/prompts': 0.10.1
+      '@clack/prompts': 0.11.0
       '@eslint/js': 9.30.1
-      '@nuxt/eslint-plugin': 1.4.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      '@stylistic/eslint-plugin': 4.4.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      '@nuxt/eslint-plugin': 1.5.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      '@stylistic/eslint-plugin': 5.1.0(eslint@9.30.1(jiti@2.4.2))
       '@typescript-eslint/eslint-plugin': 8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/parser': 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.30.1(jiti@2.4.2)
       eslint-config-flat-gitignore: 2.1.0(eslint@9.30.1(jiti@2.4.2))
       eslint-flat-config-utils: 2.1.0
       eslint-merge-processors: 2.0.0(eslint@9.30.1(jiti@2.4.2))
-      eslint-plugin-import-x: 4.15.2(@typescript-eslint/utils@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))
-      eslint-plugin-jsdoc: 50.8.0(eslint@9.30.1(jiti@2.4.2))
+      eslint-plugin-import-lite: 0.3.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      eslint-plugin-jsdoc: 51.3.3(eslint@9.30.1(jiti@2.4.2))
       eslint-plugin-regexp: 2.9.0(eslint@9.30.1(jiti@2.4.2))
       eslint-plugin-unicorn: 59.0.1(eslint@9.30.1(jiti@2.4.2))
-      eslint-plugin-vue: 10.2.0(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.1.3(eslint@9.30.1(jiti@2.4.2)))
+      eslint-plugin-vue: 10.3.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.2.0(eslint@9.30.1(jiti@2.4.2)))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))
       globals: 16.3.0
       local-pkg: 1.1.1
       pathe: 2.0.3
-      vue-eslint-parser: 10.1.3(eslint@9.30.1(jiti@2.4.2))
+      vue-eslint-parser: 10.2.0(eslint@9.30.1(jiti@2.4.2))
     transitivePeerDependencies:
-      - '@typescript-eslint/utils'
       - '@vue/compiler-sfc'
-      - eslint-import-resolver-node
       - supports-color
       - typescript
 
-  '@nuxt/eslint-plugin@1.4.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
+  '@nuxt/eslint-plugin@1.5.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.35.1
       '@typescript-eslint/utils': 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
@@ -5737,27 +5608,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.4.1(@typescript-eslint/utils@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))':
+  '@nuxt/eslint@1.5.1(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@eslint/config-inspector': 1.1.0(eslint@9.30.1(jiti@2.4.2))
       '@nuxt/devtools-kit': 2.6.2(magicast@0.3.5)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))
-      '@nuxt/eslint-config': 1.4.1(@typescript-eslint/utils@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      '@nuxt/eslint-plugin': 1.4.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      '@nuxt/eslint-config': 1.5.1(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      '@nuxt/eslint-plugin': 1.5.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       '@nuxt/kit': 3.17.6(magicast@0.3.5)
       chokidar: 4.0.3
       eslint: 9.30.1(jiti@2.4.2)
       eslint-flat-config-utils: 2.1.0
-      eslint-typegen: 2.2.0(eslint@9.30.1(jiti@2.4.2))
+      eslint-typegen: 2.2.1(eslint@9.30.1(jiti@2.4.2))
       find-up: 7.0.0
       get-port-please: 3.1.2
       mlly: 1.7.4
       pathe: 2.0.3
       unimport: 5.1.0
     transitivePeerDependencies:
-      - '@typescript-eslint/utils'
       - '@vue/compiler-sfc'
       - bufferutil
-      - eslint-import-resolver-node
       - eslint-plugin-format
       - magicast
       - supports-color
@@ -6268,18 +6137,6 @@ snapshots:
 
   '@speed-highlight/core@1.2.7': {}
 
-  '@stylistic/eslint-plugin@4.4.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
-    dependencies:
-      '@typescript-eslint/utils': 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      eslint: 9.30.1(jiti@2.4.2)
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      estraverse: 5.3.0
-      picomatch: 4.0.2
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@stylistic/eslint-plugin@5.1.0(eslint@9.30.1(jiti@2.4.2))':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1(jiti@2.4.2))
@@ -6434,65 +6291,6 @@ snapshots:
       hookable: 5.5.3
       unhead: 2.0.11
       vue: 3.5.17(typescript@5.8.3)
-
-  '@unrs/resolver-binding-android-arm-eabi@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-android-arm64@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-darwin-arm64@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-darwin-x64@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-freebsd-x64@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-linux-arm-gnueabihf@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-linux-arm-musleabihf@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-linux-arm64-gnu@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-linux-arm64-musl@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-linux-ppc64-gnu@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-linux-riscv64-gnu@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-linux-riscv64-musl@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-linux-s390x-gnu@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-linux-x64-gnu@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-linux-x64-musl@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-wasm32-wasi@1.9.0':
-    dependencies:
-      '@napi-rs/wasm-runtime': 0.2.11
-    optional: true
-
-  '@unrs/resolver-binding-win32-arm64-msvc@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-win32-ia32-msvc@1.9.0':
-    optional: true
-
-  '@unrs/resolver-binding-win32-x64-msvc@1.9.0':
-    optional: true
 
   '@vercel/nft@0.29.4(rollup@4.44.0)':
     dependencies:
@@ -6679,14 +6477,14 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/eslint-config-typescript@14.5.1(eslint-plugin-vue@10.2.0(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.1.3(eslint@9.30.1(jiti@2.4.2))))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
+  '@vue/eslint-config-typescript@14.6.0(eslint-plugin-vue@10.3.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.2.0(eslint@9.30.1(jiti@2.4.2))))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/utils': 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.30.1(jiti@2.4.2)
-      eslint-plugin-vue: 10.2.0(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.1.3(eslint@9.30.1(jiti@2.4.2)))
+      eslint-plugin-vue: 10.3.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.2.0(eslint@9.30.1(jiti@2.4.2)))
       fast-glob: 3.3.3
       typescript-eslint: 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      vue-eslint-parser: 10.1.3(eslint@9.30.1(jiti@2.4.2))
+      vue-eslint-parser: 10.2.0(eslint@9.30.1(jiti@2.4.2))
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -7440,13 +7238,6 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
-  eslint-import-context@0.1.8(unrs-resolver@1.9.0):
-    dependencies:
-      get-tsconfig: 4.10.1
-      stable-hash-x: 0.1.1
-    optionalDependencies:
-      unrs-resolver: 1.9.0
-
   eslint-json-compat-utils@0.2.1(eslint@9.30.1(jiti@2.4.2))(jsonc-eslint-parser@2.4.0):
     dependencies:
       eslint: 9.30.1(jiti@2.4.2)
@@ -7457,26 +7248,17 @@ snapshots:
     dependencies:
       eslint: 9.30.1(jiti@2.4.2)
 
-  eslint-plugin-import-x@4.15.2(@typescript-eslint/utils@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2)):
+  eslint-plugin-import-lite@0.3.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1(jiti@2.4.2))
       '@typescript-eslint/types': 8.35.1
-      comment-parser: 1.4.1
-      debug: 4.4.1
       eslint: 9.30.1(jiti@2.4.2)
-      eslint-import-context: 0.1.8(unrs-resolver@1.9.0)
-      is-glob: 4.0.3
-      minimatch: 10.0.3
-      semver: 7.7.2
-      stable-hash-x: 0.1.1
-      unrs-resolver: 1.9.0
     optionalDependencies:
-      '@typescript-eslint/utils': 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-    transitivePeerDependencies:
-      - supports-color
+      typescript: 5.8.3
 
-  eslint-plugin-jsdoc@50.8.0(eslint@9.30.1(jiti@2.4.2)):
+  eslint-plugin-jsdoc@51.3.3(eslint@9.30.1(jiti@2.4.2)):
     dependencies:
-      '@es-joy/jsdoccomment': 0.50.2
+      '@es-joy/jsdoccomment': 0.52.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
       debug: 4.4.1
@@ -7559,7 +7341,7 @@ snapshots:
       semver: 7.7.2
       strip-indent: 4.0.0
 
-  eslint-plugin-vue@10.2.0(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.1.3(eslint@9.30.1(jiti@2.4.2))):
+  eslint-plugin-vue@10.3.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(vue-eslint-parser@10.2.0(eslint@9.30.1(jiti@2.4.2))):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1(jiti@2.4.2))
       eslint: 9.30.1(jiti@2.4.2)
@@ -7567,8 +7349,10 @@ snapshots:
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.7.2
-      vue-eslint-parser: 10.1.3(eslint@9.30.1(jiti@2.4.2))
+      vue-eslint-parser: 10.2.0(eslint@9.30.1(jiti@2.4.2))
       xml-name-validator: 4.0.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
 
   eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.17)(eslint@9.30.1(jiti@2.4.2)):
     dependencies:
@@ -7580,7 +7364,7 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-typegen@2.2.0(eslint@9.30.1(jiti@2.4.2)):
+  eslint-typegen@2.2.1(eslint@9.30.1(jiti@2.4.2)):
     dependencies:
       eslint: 9.30.1(jiti@2.4.2)
       json-schema-to-typescript-lite: 14.1.0
@@ -7840,10 +7624,6 @@ snapshots:
       pump: 3.0.3
 
   get-stream@8.0.1: {}
-
-  get-tsconfig@4.10.1:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   giget@2.0.0:
     dependencies:
@@ -8618,8 +8398,6 @@ snapshots:
   nanoid@5.1.5: {}
 
   nanotar@0.2.0: {}
-
-  napi-postinstall@0.2.4: {}
 
   natural-compare@1.4.0: {}
 
@@ -9490,8 +9268,6 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
-
   resolve@1.22.10:
     dependencies:
       is-core-module: 2.16.1
@@ -9716,8 +9492,6 @@ snapshots:
   speakingurl@14.0.1: {}
 
   split-on-first@3.0.0: {}
-
-  stable-hash-x@0.1.1: {}
 
   stack-trace@0.0.10: {}
 
@@ -10048,30 +9822,6 @@ snapshots:
       picomatch: 4.0.2
       webpack-virtual-modules: 0.6.2
 
-  unrs-resolver@1.9.0:
-    dependencies:
-      napi-postinstall: 0.2.4
-    optionalDependencies:
-      '@unrs/resolver-binding-android-arm-eabi': 1.9.0
-      '@unrs/resolver-binding-android-arm64': 1.9.0
-      '@unrs/resolver-binding-darwin-arm64': 1.9.0
-      '@unrs/resolver-binding-darwin-x64': 1.9.0
-      '@unrs/resolver-binding-freebsd-x64': 1.9.0
-      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.9.0
-      '@unrs/resolver-binding-linux-arm-musleabihf': 1.9.0
-      '@unrs/resolver-binding-linux-arm64-gnu': 1.9.0
-      '@unrs/resolver-binding-linux-arm64-musl': 1.9.0
-      '@unrs/resolver-binding-linux-ppc64-gnu': 1.9.0
-      '@unrs/resolver-binding-linux-riscv64-gnu': 1.9.0
-      '@unrs/resolver-binding-linux-riscv64-musl': 1.9.0
-      '@unrs/resolver-binding-linux-s390x-gnu': 1.9.0
-      '@unrs/resolver-binding-linux-x64-gnu': 1.9.0
-      '@unrs/resolver-binding-linux-x64-musl': 1.9.0
-      '@unrs/resolver-binding-wasm32-wasi': 1.9.0
-      '@unrs/resolver-binding-win32-arm64-msvc': 1.9.0
-      '@unrs/resolver-binding-win32-ia32-msvc': 1.9.0
-      '@unrs/resolver-binding-win32-x64-msvc': 1.9.0
-
   unstorage@1.16.0(db0@0.3.2)(ioredis@5.6.1):
     dependencies:
       anymatch: 3.1.3
@@ -10296,7 +10046,7 @@ snapshots:
 
   vue-devtools-stub@0.1.0: {}
 
-  vue-eslint-parser@10.1.3(eslint@9.30.1(jiti@2.4.2)):
+  vue-eslint-parser@10.2.0(eslint@9.30.1(jiti@2.4.2)):
     dependencies:
       debug: 4.4.1
       eslint: 9.30.1(jiti@2.4.2)
@@ -10304,7 +10054,6 @@ snapshots:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       esquery: 1.6.0
-      lodash: 4.17.21
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -19,7 +19,10 @@ describe('ESLint Configuration', () => {
     const configNames = config.map(c => c.name).filter(Boolean);
 
     // Check for some expected configurations
-    expect(configNames).toContain('poupe/files');
-    expect(configNames).toContain('poupe/rules');
+    expect(configNames).toContain('poupe/json');
+    expect(configNames).toContain('poupe/perfectionist');
+    expect(configNames).toContain('poupe/stylistic');
+    expect(configNames).toContain('poupe/unicorn');
+    expect(configNames).toContain('poupe/vue');
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,18 +1,19 @@
 import {
-  cssRecommended,
-
   eslintRecommended,
-  jsoncRecommended,
   markdownlintRecommended,
-  perfectionistRecommended,
   poupeConfigs,
+  poupeCSSConfig,
   stylisticRecommended,
   tsdocRecommended,
   tseslintRecommended,
+
   unicornRecommended,
   vueRecommended,
+  vueSetupConfig,
 } from './configs';
-import { processCSSConfigs } from './configs/css-filter';
+import {
+  processCSSConfigs,
+} from './configs/css-filter';
 import {
   type Config,
   type InfiniteDepthConfigWithExtends,
@@ -30,17 +31,20 @@ export function defineConfig(...userConfigs: InfiniteDepthConfigWithExtends[]): 
         '**/node_modules',
       ],
     },
+
     eslintRecommended,
     tseslintRecommended,
+
+    markdownlintRecommended,
+    stylisticRecommended,
     tsdocRecommended,
     unicornRecommended,
-    perfectionistRecommended,
-    stylisticRecommended,
-    markdownlintRecommended,
     vueRecommended,
+
+    vueSetupConfig,
+
     poupeConfigs,
-    cssRecommended, // CSS configs need to come after JS configs to override rules
-    jsoncRecommended, // Move JSON config after others to ensure it takes precedence
+    poupeCSSConfig,
     userConfigs,
   );
 

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -1,56 +1,32 @@
 import {
-  poupeStylisticRules,
-  poupeUnicornRules,
-  poupeVueRules,
+  poupeJsonConfigs,
+  poupePerfectionistConfig,
+  poupeStylisticConfig,
+  poupeUnicornConfigs,
+  poupeVueConfig,
 } from './configs/index';
 import {
   type Config,
-  type Rules,
 } from './core';
 
 export {
-  cssRecommended,
   eslintRecommended,
-  jsoncRecommended,
   markdownlintRecommended,
-  perfectionistRecommended,
+  poupeCSSConfig,
   stylisticRecommended,
   tsdocRecommended,
   tseslintRecommended,
   unicornRecommended,
+
   vueRecommended,
+  vueSetupConfig,
 } from './configs/index';
 
 // poupeConfigs
-export const files: string[] = [
-  '**/*.{js,mjs,cjs}',
-  '**/*.ts',
-  '**/*.vue',
-];
-
-export const rules: Rules = {
-  ...poupeStylisticRules,
-  ...poupeUnicornRules,
-  ...poupeVueRules,
-};
-
 export const poupeConfigs: Config[] = [
-  {
-    name: 'poupe/vue-ts',
-    languageOptions: {
-      parserOptions: {
-        parser: '@typescript-eslint/parser',
-        extraFileExtensions: ['vue'],
-        sourceType: 'module',
-      },
-    },
-  },
-  {
-    name: 'poupe/files',
-    files,
-  },
-  {
-    name: 'poupe/rules',
-    rules: rules,
-  },
+  ...poupeJsonConfigs,
+  poupePerfectionistConfig,
+  poupeStylisticConfig,
+  ...poupeUnicornConfigs,
+  poupeVueConfig,
 ];

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -17,6 +17,7 @@ export {
   tsdocRecommended,
   tseslintRecommended,
   unicornRecommended,
+  unicornSetupConfig,
 
   vueRecommended,
   vueSetupConfig,

--- a/src/configs/__tests__/unicorn.test.ts
+++ b/src/configs/__tests__/unicorn.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { poupeUnicornRules } from '../unicorn';
+import { poupeUnicornConfigs } from '../unicorn';
 
 interface PreventAbbreviationsOptions {
   allowList: Record<string, boolean>
@@ -13,9 +13,15 @@ interface FilenameCaseOptions {
 }
 
 describe('unicorn configuration', () => {
+  // Find the config with unicorn rules
+  const unicornConfig = poupeUnicornConfigs.find(c => c.name === 'poupe/unicorn');
+  const filenameConfig = poupeUnicornConfigs.find(c => c.name === 'poupe/unicorn-filename');
+  const unicornRules = unicornConfig?.rules || {};
+  const filenameRules = filenameConfig?.rules || {};
+
   describe('prevent-abbreviations rule', () => {
     it('should have correct configuration', () => {
-      const rule = poupeUnicornRules['unicorn/prevent-abbreviations'];
+      const rule = unicornRules['unicorn/prevent-abbreviations'];
       expect(rule).toBeDefined();
       expect(Array.isArray(rule)).toBe(true);
       if (Array.isArray(rule)) {
@@ -24,7 +30,7 @@ describe('unicorn configuration', () => {
     });
 
     it('should allow i, j, k as variable names', () => {
-      const rule = poupeUnicornRules['unicorn/prevent-abbreviations'];
+      const rule = unicornRules['unicorn/prevent-abbreviations'];
       expect(Array.isArray(rule)).toBe(true);
       if (Array.isArray(rule) && rule.length > 1) {
         const options = rule[1] as PreventAbbreviationsOptions;
@@ -36,7 +42,7 @@ describe('unicorn configuration', () => {
     });
 
     it('should not suggest replacements for i, j, k', () => {
-      const rule = poupeUnicornRules['unicorn/prevent-abbreviations'];
+      const rule = unicornRules['unicorn/prevent-abbreviations'];
       expect(Array.isArray(rule)).toBe(true);
       if (Array.isArray(rule) && rule.length > 1) {
         const options = rule[1] as PreventAbbreviationsOptions;
@@ -49,7 +55,7 @@ describe('unicorn configuration', () => {
     });
 
     it('should allow other common abbreviations', () => {
-      const rule = poupeUnicornRules['unicorn/prevent-abbreviations'];
+      const rule = unicornRules['unicorn/prevent-abbreviations'];
       expect(Array.isArray(rule)).toBe(true);
       if (Array.isArray(rule) && rule.length > 1) {
         const options = rule[1] as PreventAbbreviationsOptions;
@@ -64,7 +70,7 @@ describe('unicorn configuration', () => {
 
   describe('filename-case rule', () => {
     it('should enforce kebab-case with exceptions for uppercase markdown files', () => {
-      const rule = poupeUnicornRules['unicorn/filename-case'];
+      const rule = filenameRules['unicorn/filename-case'];
       expect(rule).toBeDefined();
       expect(Array.isArray(rule)).toBe(true);
 

--- a/src/configs/css-filter.ts
+++ b/src/configs/css-filter.ts
@@ -3,8 +3,8 @@ import unicornPlugin from 'eslint-plugin-unicorn';
 
 import { type Config, Linter } from '../core/config';
 import { eslintRecommended } from './eslint';
-import { poupeStylisticRules, stylisticRecommended } from './stylistic';
-import { poupeUnicornRules, unicornRecommended } from './unicorn';
+import { poupeStylisticConfig } from './stylistic';
+import { poupeUnicornConfigs } from './unicorn';
 
 // Helper function for safe console warnings
 function warn(message: string): void {
@@ -339,12 +339,10 @@ export function getJavaScriptRulesToDisable(): Record<string, 'off'> {
   }
 
   // 2. Also analyze actual configs to catch core ESLint rules and any custom rules
-  const configs = [
+  const configs: Config[] = [
     eslintRecommended,
-    unicornRecommended,
-    stylisticRecommended,
-    poupeUnicornRules,
-    poupeStylisticRules,
+    ...poupeUnicornConfigs,
+    poupeStylisticConfig,
   ];
 
   for (const config of configs) {

--- a/src/configs/css.ts
+++ b/src/configs/css.ts
@@ -4,8 +4,10 @@ import { tailwindSyntax } from '@eslint/css/syntax';
 import {
   type Config,
   type Rules,
-  withConfig,
+
+  GLOB_CSS,
 } from '../core';
+
 import { tailwindV4Syntax } from './tailwind-v4-syntax';
 
 type SyntaxConfig = NonNullable<CSSLanguageOptions['customSyntax']>;
@@ -36,23 +38,21 @@ const extendedTailwindSyntax: Partial<SyntaxConfig> = {
   },
 };
 
-const languageOptions = {
+const languageOptions: CSSLanguageOptions = {
   tolerant: true, // Enable tolerant mode for Tailwind CSS compatibility
-  customSyntax: extendedTailwindSyntax,
+  customSyntax: extendedTailwindSyntax as SyntaxConfig,
 };
 
-export const cssRecommended: Config[] = withConfig(
-  {
-    name: 'poupe/css',
-    files: ['**/*.css'],
-    plugins: {
-      css,
-    },
-    language: 'css/css',
-    languageOptions: languageOptions as Config['languageOptions'],
-    rules: {
-      ...cssConfigs.recommended.rules,
-      ...poupeCssRules,
-    },
+export const poupeCSSConfig: Config = {
+  name: 'poupe/css',
+  files: [GLOB_CSS],
+  plugins: {
+    css,
   },
-);
+  language: 'css/css',
+  languageOptions: languageOptions as Config['languageOptions'],
+  rules: {
+    ...cssConfigs.recommended.rules,
+    ...poupeCssRules,
+  },
+};

--- a/src/configs/json.ts
+++ b/src/configs/json.ts
@@ -1,19 +1,26 @@
 import jsoncPlugin from 'eslint-plugin-jsonc';
 import * as jsoncParser from 'jsonc-eslint-parser';
 
-import type { Config, Rules } from '../core';
+import {
+  type Config,
+  type Rules,
 
-import { withConfig } from '../core';
+  GLOB_JSON,
+  GLOB_JSONC,
+} from '../core';
 
 const jsoncRecommendedRules = jsoncPlugin.configs['recommended-with-json'].rules as Rules;
 
-const JSONC_ALLOW_COMMENTS_FILES = [
+const GLOB_PACKAGE_JSON = '**/package.json';
+
+const JSONC_FILES = [
+  GLOB_JSONC,
   '**/.vscode/*.json',
   '**/tsconfig.json',
   '**/tsconfig.*.json',
 ];
 
-export const poupeJsonRules: Rules = {
+const poupeJsonRules: Rules = {
   // Consistent formatting
   'jsonc/indent': ['error', 2],
   'jsonc/comma-dangle': ['error', 'never'],
@@ -28,7 +35,12 @@ export const poupeJsonRules: Rules = {
   'jsonc/no-comments': 'error',
 };
 
-export const poupePackageJsonRules: Rules = {
+const poupeJsoncRules: Rules = {
+  ...poupeJsonRules,
+  'jsonc/no-comments': 'off',
+};
+
+const poupePackageJsonRules: Rules = {
   ...poupeJsonRules,
   // Sort package.json keys in standard order
   'jsonc/sort-keys': [
@@ -76,11 +88,11 @@ export const poupePackageJsonRules: Rules = {
   ],
 };
 
-export const jsoncRecommended: Config[] = withConfig(
+export const poupeJsonConfigs: Config[] = [
   {
     name: 'poupe/json',
-    files: ['**/*.json'],
-    ignores: ['**/package.json'],
+    files: [GLOB_JSON],
+    ignores: [GLOB_PACKAGE_JSON],
     plugins: {
       jsonc: jsoncPlugin,
     },
@@ -94,7 +106,7 @@ export const jsoncRecommended: Config[] = withConfig(
   },
   {
     name: 'poupe/package-json',
-    files: ['**/package.json'],
+    files: [GLOB_PACKAGE_JSON],
     plugins: {
       jsonc: jsoncPlugin,
     },
@@ -107,10 +119,11 @@ export const jsoncRecommended: Config[] = withConfig(
     },
   },
   {
-    name: 'poupe/allow-json-comments',
-    files: JSONC_ALLOW_COMMENTS_FILES,
+    name: 'poupe/jsonc',
+    files: JSONC_FILES,
     rules: {
-      'jsonc/no-comments': 'off',
+      ...jsoncRecommendedRules,
+      ...poupeJsoncRules,
     },
   },
-);
+];

--- a/src/configs/perfectionist.ts
+++ b/src/configs/perfectionist.ts
@@ -3,11 +3,12 @@ import perfectionist from 'eslint-plugin-perfectionist';
 import {
   type Config,
   type Rules,
-  withConfig,
+
+  GLOB_SRC,
+  GLOB_VUE,
 } from '../core';
 
-// Perfectionist rules for import/export sorting
-export const poupePerfectionistRules: Rules = {
+const poupePerfectionistRules: Rules = {
   'perfectionist/sort-imports': [
     'error',
     {
@@ -83,11 +84,11 @@ export const poupePerfectionistRules: Rules = {
   ],
 };
 
-export const perfectionistRecommended: Config[] = withConfig({
+export const poupePerfectionistConfig: Config = {
   name: 'poupe/perfectionist',
-  files: ['**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx,vue}'],
+  files: [GLOB_SRC, GLOB_VUE],
   plugins: {
     perfectionist,
   },
   rules: poupePerfectionistRules,
-});
+};

--- a/src/configs/perfectionist.ts
+++ b/src/configs/perfectionist.ts
@@ -15,8 +15,9 @@ export const poupePerfectionistRules: Rules = {
       order: 'asc',
       ignoreCase: true,
       internalPattern: ['^~/.+', '^@/.+', String.raw`^\.\./.+`, String.raw`^\./.+`],
-      newlinesBetween: 'always',
+      newlinesBetween: 'ignore',
       maxLineLength: undefined,
+      partitionByNewLine: true,
       groups: [
         'type',
         ['builtin', 'external'],
@@ -57,6 +58,7 @@ export const poupePerfectionistRules: Rules = {
       ignoreAlias: false,
       specialCharacters: 'keep',
       groupKind: 'mixed',
+      partitionByNewLine: true,
     },
   ],
   'perfectionist/sort-named-exports': [

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -1,12 +1,16 @@
 import stylisticPlugin from '@stylistic/eslint-plugin';
 
-import type {
-  Rules,
+import {
+  type Config,
+  type Rules,
+
+  GLOB_SRC,
+  GLOB_VUE,
 } from '../core';
 
 export const stylisticRecommended = stylisticPlugin.configs.recommended;
 
-export const poupeStylisticRules: Rules = {
+const poupeStylisticRules: Rules = {
   '@stylistic/arrow-parens': 'error',
   '@stylistic/brace-style': ['error', '1tbs'],
   '@stylistic/indent': ['error', 2],
@@ -18,4 +22,10 @@ export const poupeStylisticRules: Rules = {
   '@stylistic/operator-linebreak': ['error', 'after', {
     overrides: {},
   }],
+};
+
+export const poupeStylisticConfig: Config = {
+  name: 'poupe/stylistic',
+  files: [GLOB_SRC, GLOB_VUE],
+  rules: poupeStylisticRules,
 };

--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -12,6 +12,14 @@ const { configs: unicornConfigs } = unicornPlugin;
 
 export const unicornRecommended: Config = unicornConfigs.recommended;
 
+/** Bare unicorn plugin setup (just the plugin, no rules) */
+export const unicornSetupConfig: Config = {
+  name: 'poupe/unicorn-setup',
+  plugins: {
+    unicorn: unicornPlugin,
+  },
+};
+
 // unicorn/prevent-abbreviations
 const abbreviations = [
   'attr',

--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -1,8 +1,11 @@
 import unicornPlugin from 'eslint-plugin-unicorn';
 
-import type {
-  Config,
-  Rules,
+import {
+  type Config,
+  type Rules,
+
+  GLOB_SRC,
+  GLOB_VUE,
 } from '../core';
 
 const { configs: unicornConfigs } = unicornPlugin;
@@ -42,7 +45,7 @@ const replacements = Object.fromEntries(
 );
 
 // Poupe Rules
-export const poupeUnicornRules: Rules = {
+const poupeUnicornFilenameRules: Rules = {
   'unicorn/filename-case': [
     'error',
     {
@@ -54,6 +57,9 @@ export const poupeUnicornRules: Rules = {
       ],
     },
   ],
+};
+
+const poupeUnicornRules: Rules = {
   'unicorn/no-array-for-each': 'error',
   'unicorn/no-named-default': 'off',
   'unicorn/no-useless-undefined': 'off',
@@ -66,3 +72,14 @@ export const poupeUnicornRules: Rules = {
   ],
   'unicorn/switch-case-braces': 'off',
 };
+
+export const poupeUnicornConfigs: Config[] = [
+  {
+    name: 'poupe/unicorn-filename',
+    rules: poupeUnicornFilenameRules,
+  }, {
+    name: 'poupe/unicorn',
+    files: [GLOB_SRC, GLOB_VUE],
+    rules: poupeUnicornRules,
+  },
+];

--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -2,7 +2,8 @@ import vuePlugin from 'eslint-plugin-vue';
 
 import {
   type Config,
-  type Rules,
+
+  GLOB_VUE,
 
   withConfig,
 } from '../core';
@@ -23,14 +24,30 @@ function restrictVueRulesToVueFiles(config: Config): Config {
   // Add .vue file pattern to configs without file restrictions
   return {
     ...config,
-    files: ['*.vue', '**/*.vue'],
+    files: [GLOB_VUE],
   };
 }
+
+export const vueSetupConfig: Config = {
+  name: 'poupe/vue-setup',
+  files: [GLOB_VUE],
+  languageOptions: {
+    parserOptions: {
+      parser: '@typescript-eslint/parser',
+      extraFileExtensions: ['vue'],
+      sourceType: 'module',
+    },
+  },
+};
 
 export const vueRecommended: Config[] = withConfig(
   vueConfigs['flat/recommended'].map(config => restrictVueRulesToVueFiles(config)),
 );
 
-export const poupeVueRules: Rules = {
-  'vue/multi-word-component-names': 'off',
+export const poupeVueConfig: Config = {
+  name: 'poupe/vue',
+  files: [GLOB_VUE],
+  rules: {
+    'vue/multi-word-component-names': 'off',
+  },
 };

--- a/src/core/globs.ts
+++ b/src/core/globs.ts
@@ -1,0 +1,5 @@
+export const GLOB_CSS = '**/*.css';
+export const GLOB_JSON = '**/*.json';
+export const GLOB_JSONC = '**/*.jsonc';
+export const GLOB_SRC = '**/*.?([cm])[jt]s?(x)';
+export const GLOB_VUE = '**/*.vue';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,2 +1,3 @@
 export * from './config';
+export * from './globs';
 export * from './utils';

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,11 +1,8 @@
 import {
-  files,
-  // cssRecommended, // TODO: CSS support disabled - see sharedNuxtRules comment
-  jsoncRecommended,
-
   markdownlintRecommended,
-  perfectionistRecommended,
-  rules,
+  // poupeCSSConfig, // TODO: CSS support disabled - see sharedNuxtRules comment
+
+  poupeConfigs,
   tsdocRecommended,
   unicornRecommended,
 } from './configs';
@@ -16,53 +13,51 @@ import {
   withConfig,
   withoutPlugin,
   withoutRules,
-} from './core/index';
+} from './core';
 
-const sharedNuxtRules: InfiniteDepthConfigWithExtends = [
+const sharedNuxtConfigs: InfiniteDepthConfigWithExtends = [
   // TODO: CSS support is temporarily disabled for Nuxt configurations
   // @nuxt/eslint-config (used by @nuxt/eslint) applies JavaScript/TypeScript
   // rules globally without file restrictions. Their regexp and @stylistic
   // plugin rules attempt to parse CSS files as JavaScript, causing TypeScript
   // AST errors. This needs to be fixed upstream in @nuxt/eslint-config/flat.
   // See: https://github.com/poupe-ui/eslint-config/issues/138
-  // cssRecommended,
-  perfectionistRecommended,
+  // poupeCSSConfig,
+
+  unicornRecommended,
   tsdocRecommended,
   markdownlintRecommended,
-  {
-    name: 'poupe/files',
-    files,
-  },
-  {
-    name: 'poupe/rules',
-    rules,
-  },
-  jsoncRecommended, // Move JSON config after others to ensure it takes precedence
+
+  poupeConfigs,
 ];
 
 /** rules for nuxt projects */
 export const forNuxt = (...userConfigs: InfiniteDepthConfigWithExtends[]): Config[] => withConfig(
-  unicornRecommended,
-  sharedNuxtRules,
-  userConfigs,
+  sharedNuxtConfigs,
+  ...userConfigs,
 );
 
-/** rules for nuxt modules */
-const [unicornConfig] = withoutPlugin('unicorn', unicornRecommended);
-
-const rulesForModules = withoutRules(unicornConfig.rules,
+/** rules not for nuxt modules */
+const rulesNotForModules = new Set([
   /** disabled because they are not supported by the version of the unicorn plugin already loaded */
   'unicorn/no-unnecessary-array-flat-depth',
   'unicorn/no-unnecessary-array-splice-count',
   'unicorn/no-unnecessary-slice-end',
   'unicorn/prefer-single-call',
-);
+]);
 
-export const forNuxtModules = (...userConfigs: InfiniteDepthConfigWithExtends[]): Config[] => withConfig(
-  {
-    ...unicornConfig,
-    rules: rulesForModules,
-  },
-  sharedNuxtRules,
-  userConfigs,
-);
+const removeUnsupportedRulesForModules = (c: Config): Config => {
+  if ('rules' in c && c.rules) {
+    return {
+      ...c,
+      rules: withoutRules(c.rules, ...rulesNotForModules),
+    };
+  }
+
+  return c;
+};
+
+export const forNuxtModules = (...userConfigs: InfiniteDepthConfigWithExtends[]): Config[] => {
+  const configs = withoutPlugin('unicorn', ...forNuxt(...userConfigs));
+  return configs.map(c => removeUnsupportedRulesForModules(c));
+};

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -5,6 +5,7 @@ import {
   poupeConfigs,
   tsdocRecommended,
   unicornRecommended,
+  unicornSetupConfig,
 } from './configs';
 import {
   type Config,
@@ -17,10 +18,9 @@ import {
 
 const sharedNuxtConfigs: InfiniteDepthConfigWithExtends = [
   // TODO: CSS support is temporarily disabled for Nuxt configurations
-  // @nuxt/eslint-config (used by @nuxt/eslint) applies JavaScript/TypeScript
-  // rules globally without file restrictions. Their regexp and @stylistic
-  // plugin rules attempt to parse CSS files as JavaScript, causing TypeScript
-  // AST errors. This needs to be fixed upstream in @nuxt/eslint-config/flat.
+  // While `@nuxt/eslint` v1.5.0+ adds file restrictions to its configs, there
+  // may still be edge cases where JavaScript/TypeScript rules leak to CSS files.
+  // Re-enable once we confirm all CSS parsing issues are resolved.
   // See: https://github.com/poupe-ui/eslint-config/issues/138
   // poupeCSSConfig,
 
@@ -58,6 +58,10 @@ const removeUnsupportedRulesForModules = (c: Config): Config => {
 };
 
 export const forNuxtModules = (...userConfigs: InfiniteDepthConfigWithExtends[]): Config[] => {
+  // Remove unicorn plugin to avoid conflicts with `@nuxt/eslint`'s own unicorn instance
   const configs = withoutPlugin('unicorn', ...forNuxt(...userConfigs));
-  return configs.map(c => removeUnsupportedRulesForModules(c));
+
+  // Add bare unicorn plugin setup to ensure our rules can still reference it
+  // This prevents "Could not find plugin 'unicorn'" errors while avoiding conflicts
+  return [unicornSetupConfig, ...configs.map(c => removeUnsupportedRulesForModules(c))];
 };


### PR DESCRIPTION
## Summary

Major refactoring of the ESLint configuration structure to improve modularity and maintainability, plus enhanced Nuxt module support.

## Key Changes

### 🏗️ Configuration Architecture Overhaul

- **Restructured exports**: Moved from exporting just rules to complete ESLint config objects
- **Better modularity**: Each config now includes its own file patterns
- **Clearer naming**: Renamed exports for clarity (e.g., `cssRecommended` → `poupeCSSConfig`)
- **Centralized globs**: New `core/globs` module with common file patterns (`GLOB_CSS`, `GLOB_SRC`, `GLOB_VUE`)

### 🔧 Enhanced Nuxt Support

- **Fixed plugin conflicts**: Added `unicornSetupConfig` to resolve unicorn plugin issues in Nuxt modules
- **Updated dependencies**: Bumped `@nuxt/eslint` to v1.5.1 which adds file restrictions
- **Documented pattern**: Added comprehensive documentation for the plugin resolution pattern

### 📦 Import Organization

- **Partition by newline**: Enhanced perfectionist configuration to respect empty lines as import group separators
- **Better grouping**: Allows logical organization of imports while maintaining automatic sorting

## Breaking Changes

- Configuration exports have been renamed
- Configs now return complete ESLint objects instead of just rules
- Some internal APIs have changed

## Testing

- [x] All unit tests passing
- [x] Examples validated (playground-standard, playground-nuxt, playground-nuxt-module)
- [x] Linting and type checking pass

## Related Issues

- Partially addresses #138 (CSS support for Nuxt - groundwork laid but not yet enabled)