### PR TITLE
ci: add npm publish workflow and set public access

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.14.0'
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: true
+      - run: npm install -g npm@latest
+      - name: prepack
+        run: pnpm prepack
+      - name: publish
+        run: npm publish

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "node": ">= 20.19.0",
     "pnpm": ">= 10.30.3"
   },
-  "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017"
+  "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## Summary

- Add publish.yml workflow using npm trusted publishing (OIDC)
  to publish on version tags
- Set publishConfig.access to public in package.json
- Uses npm-publish environment for deployment protection

## Test plan

- [ ] Configure npm-publish environment on GitHub
- [ ] Configure trusted publisher on npmjs.com
- [ ] Test publish workflow on next tag push
