### PR TITLE
fix(ci): scope pull-requests permission to job in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,15 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   make:
     runs-on: ubuntu-latest
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Move `pull-requests: write` from the workflow-level `permissions:`
block in `.github/workflows/build.yml` down to the `make` job
(least privilege).

The job needs `pull-requests: write` so `pkg-pr-new` can post
install comments on pull requests; nothing else in this workflow
does.

## Notes

Job-level `permissions:` overrides workflow-level entirely (it
does not merge), so `contents: read` is re-declared on the job
to keep `actions/checkout` working.

Same fix is being applied on `eslint-plugin-tailwindcss` in a
parallel PR.

## Test plan

- [ ] CI green on this PR
- [ ] `pkg-pr-new` install comment still posted on the PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to optimize permission settings for the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->