### PR TITLE
feat(unicorn): add withAbbreviations extension primitive

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ import {
   withConfig,
 } from './core';
 
+export { withAbbreviations } from './configs/unicorn';
 export type { Config, InfiniteDepthConfigWithExtends, Plugin, Rules } from './core';
 export { Linter, reconcilePlugins, withConfig } from './core';
 export * from './core/globs';

--- a/src/configs/__tests__/unicorn.test.ts
+++ b/src/configs/__tests__/unicorn.test.ts
@@ -1,12 +1,44 @@
+import unicornPlugin from 'eslint-plugin-unicorn';
 import { describe, expect, it } from 'vitest';
 
-import { poupeUnicornConfigs } from '../unicorn';
+import { type Config, GLOB_SRC, GLOB_VUE, Linter } from '../../core';
+import { poupeUnicornConfigs, withAbbreviations } from '../unicorn';
 import { mustConfigByName } from './test-utils';
 
 interface PreventAbbreviationsOptions {
   allowList: Record<string, boolean>
   replacements: Record<string, boolean | string | string[]>
 }
+
+const preventAbbreviationsOptions = (
+  rule: unknown,
+): PreventAbbreviationsOptions => {
+  if (!Array.isArray(rule) || rule.length < 2) {
+    throw new Error('expected prevent-abbreviations to carry options');
+  }
+  return rule[1] as PreventAbbreviationsOptions;
+};
+
+// Lint a snippet through the unicorn plugin plus the supplied blocks,
+// proving ESLint honours the emitted options end-to-end — not just that
+// the returned object has the right shape.
+const lintSource = (
+  code: string,
+  ...configs: Config[]
+): Linter.LintMessage[] => {
+  const linter = new Linter();
+  return linter.verify(
+    code,
+    [
+      { plugins: { unicorn: unicornPlugin } },
+      ...configs,
+    ],
+    'example.ts',
+  );
+};
+
+const flagsAbbreviation = (messages: Linter.LintMessage[]): boolean =>
+  messages.some((m) => m.ruleId === 'unicorn/prevent-abbreviations');
 
 interface FilenameCaseOptions {
   case: string
@@ -63,6 +95,81 @@ describe('unicorn configuration', () => {
           expect(options.allowList[abbr]).toBe(true);
         }
       }
+    });
+  });
+
+  describe('withAbbreviations', () => {
+    it('emits a named block scoped to the preset files', () => {
+      const block = withAbbreviations(['doc']);
+      expect(block.name).toBe('poupe/unicorn-abbreviations');
+      expect(block.files).toEqual([GLOB_SRC, GLOB_VUE]);
+    });
+
+    it('allows the new tokens and neutralises their replacements', () => {
+      const rule = withAbbreviations(['doc', 'docs', 'dir'])
+        .rules!['unicorn/prevent-abbreviations'];
+      const options = preventAbbreviationsOptions(rule);
+
+      for (const token of ['doc', 'docs', 'dir']) {
+        expect(options.allowList[token]).toBe(true);
+        expect(options.replacements[token]).toBe(false);
+      }
+    });
+
+    it('preserves the base Poupe abbreviations (merged over the preset)', () => {
+      const rule = withAbbreviations(['doc'])
+        .rules!['unicorn/prevent-abbreviations'];
+      const options = preventAbbreviationsOptions(rule);
+
+      // Base allow tokens survive the merge.
+      for (const token of ['env', 'err', 'fn', 'pkg', 'props', 'utils']) {
+        expect(options.allowList[token]).toBe(true);
+      }
+      // i/j/k stay allowed but unmapped, as in the preset.
+      expect(options.allowList.i).toBe(true);
+      expect(options.replacements.i).toBeUndefined();
+    });
+
+    it('does not mutate the shared preset configuration', () => {
+      const presetRule = mustConfigByName(poupeUnicornConfigs, 'poupe/unicorn')
+        .rules!['unicorn/prevent-abbreviations'];
+      const preset = preventAbbreviationsOptions(presetRule);
+
+      withAbbreviations(['doc', 'docs', 'dir']);
+
+      expect(preset.allowList.doc).toBeUndefined();
+      expect(preset.replacements.dir).toBeUndefined();
+    });
+
+    it('re-emits the base options unchanged for an empty token list', () => {
+      const rule = withAbbreviations([])
+        .rules!['unicorn/prevent-abbreviations'];
+      const options = preventAbbreviationsOptions(rule);
+
+      expect(options.allowList.env).toBe(true);
+      expect(options.allowList.doc).toBeUndefined();
+    });
+  });
+
+  describe('withAbbreviations (integration)', () => {
+    const preset = mustConfigByName(poupeUnicornConfigs, 'poupe/unicorn');
+
+    it('flags an unlisted abbreviation under the bare preset', () => {
+      expect(flagsAbbreviation(lintSource('const doc = 1;', preset))).toBe(true);
+    });
+
+    it('allows the token once withAbbreviations adds it', () => {
+      const messages = lintSource(
+        'const doc = 1;', preset, withAbbreviations(['doc']),
+      );
+      expect(flagsAbbreviation(messages)).toBe(false);
+    });
+
+    it('keeps the rule active for other abbreviations', () => {
+      const messages = lintSource(
+        'const arr = [];', preset, withAbbreviations(['doc']),
+      );
+      expect(flagsAbbreviation(messages)).toBe(true);
     });
   });
 

--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -73,13 +73,53 @@ const poupeUnicornRules: Rules = {
   'unicorn/switch-case-braces': 'off',
 };
 
+// Source and Vue files share the prevent-abbreviations scope; extension
+// primitives reuse this so their blocks stay aligned with the preset.
+const poupeUnicornFiles = [GLOB_SRC, GLOB_VUE];
+
 export const poupeUnicornConfigs: Config[] = [
   {
     name: 'poupe/unicorn-filename',
     rules: poupeUnicornFilenameRules,
   }, {
     name: 'poupe/unicorn',
-    files: [GLOB_SRC, GLOB_VUE],
+    files: poupeUnicornFiles,
     rules: poupeUnicornRules,
   },
 ];
+
+/**
+ * Extends `unicorn/prevent-abbreviations` with additional allowed tokens.
+ *
+ * Each token is whitelisted (`allowList`) and has any upstream substring
+ * replacement neutralised (`replacements`), then merged over Poupe's base
+ * options. ESLint replaces a rule's options wholesale rather than merging
+ * them, so the returned block re-declares the rule with the *complete*
+ * combined configuration — Poupe's defaults plus the new tokens.
+ *
+ * Append it after the preset (e.g. as a `defineConfig` user config) to
+ * allow project-specific proper-noun identifiers (`Doc`, `Dir`, …) whose
+ * substrings collide with the upstream abbreviation map, without losing
+ * Poupe's own allowances.
+ *
+ * @param tokens - Identifiers to allow (e.g. `['doc', 'docs', 'dir']`)
+ * @returns A config block re-emitting `unicorn/prevent-abbreviations`
+ */
+export function withAbbreviations(tokens: readonly string[]): Config {
+  const allowed = Object.fromEntries(tokens.map((s) => [s, true]));
+  const neutralised = Object.fromEntries(tokens.map((s) => [s, false]));
+
+  return {
+    name: 'poupe/unicorn-abbreviations',
+    files: poupeUnicornFiles,
+    rules: {
+      'unicorn/prevent-abbreviations': [
+        'error',
+        {
+          allowList: { ...allowList, ...allowed },
+          replacements: { ...replacements, ...neutralised },
+        },
+      ],
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds `withAbbreviations(tokens)`, a public helper for extending
`unicorn/prevent-abbreviations` with project-specific allowed identifiers
without re-declaring the rule or losing Poupe's own allowances.

Consumers whose code carries proper-noun identifiers — `Doc`, `Dir`,
`Docs` — hit the upstream abbreviation map (`doc → document`,
`dir → directory`), which flags them and auto-fixes to wrong English
words. Until now the only ways to allow such tokens were to re-declare
the whole rule entry from scratch (losing drift safety when Poupe's list
changes) or to read the entry back out of `poupeConfigs` and rebuild it
by hand (casting the options bag and depending on the `poupe/unicorn`
block name). This helper removes that friction.

## How it works

```ts
import { defineConfig, withAbbreviations } from '@poupe/eslint-config';

export default defineConfig(
  withAbbreviations(['doc', 'docs', 'dir']),
);
```

`withAbbreviations` builds from Poupe's internal `allowList` /
`replacements`, adds each token (whitelisted, and its substring
replacement neutralised), and returns a config block re-emitting
`unicorn/prevent-abbreviations`. ESLint replaces a rule's options
wholesale rather than merging them, so the block carries the *complete*
combined configuration — the preset's defaults plus the new tokens.
Append it after the preset (as a `defineConfig` user config) and it
overrides the rule for the same source/Vue scope while leaving the rest
of `poupe/unicorn` intact.

It is surfaced alongside the other `with*` composition helpers
(`withConfig`, `withPoupe`, `reconcilePlugins`).

## Tests

- Unit: block shape, token allow/neutralise, base-abbreviations survive
  the merge, no mutation of the shared preset, empty-token list re-emits
  the base unchanged.
- Integration: lints real snippets through `Linter.verify` — an unlisted
  abbreviation is flagged under the bare preset, allowed once
  `withAbbreviations` is composed, and the rule stays active for other
  abbreviations.

## Test plan

- `pnpm precommit` green from a clean tree (lint, type-check:all, build,
  test:compat, full suite — 149 tests).
- No dependency or lockfile changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `withAbbreviations` helper function to customize abbreviation handling within the unicorn preset configuration, enabling selective whitelisting of abbreviation tokens.

* **Tests**
  * Expanded test coverage with comprehensive unit and integration tests for abbreviation configuration, including ESLint rule verification and preset merging validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->