### PR TITLE
release: v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Internal
+
+- **deps**: Deduplicated `semver` onto a single 7.8.3 instance,
+  dropping the redundant 7.8.2 copy
+
 ## [0.9.1] - 2026-04-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-09
+
+### Added
+
+- **unicorn**: New `withAbbreviations(tokens)` export — extends
+  `unicorn/prevent-abbreviations` with project-specific allowed
+  identifiers, re-emitting the complete merged rule options (ESLint
+  replaces rule options wholesale rather than deep-merging)
+
+### Fixed
+
+- **json**: Restored the `recommended-with-json` entry-1 core-rule
+  disables (`strict`, `no-unused-expressions`, `no-unused-vars`) that
+  a positional `[2].rules` read silently dropped — these core rules
+  leaked onto JSON/JSONC files when enabled globally. Added a
+  `mergeRules` core helper that folds rules across every config entry
+
+### Changed
+
+- **deps**: Dropped the obsolete `oxc-parser` override (a Jul-2025
+  CI native-bindings workaround, confirmed no longer needed);
+  normalised version ranges to `^` for non-`0.0.x` dependencies
+  (shipped `tailwind-csstree` `~0.3.0` → `^0.3.0`)
+
 ### Internal
 
 - **deps**: Deduplicated `semver` onto a single 7.8.3 instance,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/eslint-config",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "description": "Sharable ESLint configuration preset for Poupe UI projects with TypeScript, Vue.js, and Tailwind CSS support",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4938,11 +4938,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.8.2:
-    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.3:
     resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
     engines: {node: '>=10'}
@@ -6493,7 +6488,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
       nopt: 8.1.0
-      semver: 7.8.2
+      semver: 7.8.3
       tar: 7.4.3
     transitivePeerDependencies:
       - encoding
@@ -6584,7 +6579,7 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       scule: 1.3.0
-      semver: 7.8.2
+      semver: 7.8.3
       srvx: 0.11.16
       std-env: 4.1.0
       tinyclip: 0.1.12
@@ -6626,7 +6621,7 @@ snapshots:
       magicast: 0.5.2
       pathe: 2.0.3
       pkg-types: 2.3.1
-      semver: 7.8.2
+      semver: 7.8.3
 
   '@nuxt/devtools@3.2.4(@vitejs/devtools@0.1.13(@netlify/blobs@9.1.2)(@pnpm/logger@1001.0.1)(db0@0.3.4)(ioredis@5.11.1)(typescript@5.9.3)(vite@7.3.5(@types/node@24.0.3)(jiti@2.7.0)(terser@5.43.1)(yaml@2.9.0)))(vite@7.3.5(@types/node@24.0.3)(jiti@2.7.0)(terser@5.43.1)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))':
     dependencies:
@@ -6653,7 +6648,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
-      semver: 7.8.2
+      semver: 7.8.3
       simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 2.0.0
@@ -6757,7 +6752,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 3.0.1
       scule: 1.3.0
-      semver: 7.8.2
+      semver: 7.8.3
       tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
@@ -6782,7 +6777,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 3.0.1
       scule: 1.3.0
-      semver: 7.8.2
+      semver: 7.8.3
       tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
@@ -7669,7 +7664,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3
       minimatch: 10.2.4
-      semver: 7.8.2
+      semver: 7.8.3
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -7684,7 +7679,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.58.0
       debug: 4.4.3
       minimatch: 10.2.4
-      semver: 7.8.2
+      semver: 7.8.3
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -8896,7 +8891,7 @@ snapshots:
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 10.2.4
-      semver: 7.8.2
+      semver: 7.8.3
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
@@ -8918,7 +8913,7 @@ snapshots:
       html-entities: 2.6.0
       object-deep-merge: 2.0.0
       parse-imports-exports: 0.2.4
-      semver: 7.8.2
+      semver: 7.8.3
       spdx-expression-parse: 4.0.0
       to-valid-identifier: 1.0.0
     transitivePeerDependencies:
@@ -8994,7 +8989,7 @@ snapshots:
       pluralize: 8.0.0
       regexp-tree: 0.1.27
       regjsparser: 0.13.0
-      semver: 7.8.2
+      semver: 7.8.3
       strip-indent: 4.1.1
 
   eslint-plugin-vue@10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.7.0)))(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.7.0))):
@@ -9004,7 +8999,7 @@ snapshots:
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
-      semver: 7.8.2
+      semver: 7.8.3
       vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@2.7.0))
       xml-name-validator: 4.0.0
     optionalDependencies:
@@ -9561,7 +9556,7 @@ snapshots:
     dependencies:
       acorn: 8.16.0
       eslint-visitor-keys: 5.0.1
-      semver: 7.8.2
+      semver: 7.8.3
 
   katex@0.16.38:
     dependencies:
@@ -9964,7 +9959,7 @@ snapshots:
       pkg-types: 2.3.1
       postcss: 8.5.15
       postcss-nested: 7.0.2(postcss@8.5.15)
-      semver: 7.8.2
+      semver: 7.8.3
       tinyglobby: 0.2.17
     optionalDependencies:
       typescript: 5.9.3
@@ -10063,7 +10058,7 @@ snapshots:
       rollup: 4.61.1
       rollup-plugin-visualizer: 7.0.1(rollup@4.61.1)
       scule: 1.3.0
-      semver: 7.8.2
+      semver: 7.8.3
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
@@ -10211,7 +10206,7 @@ snapshots:
       pkg-types: 2.3.1
       rou3: 0.8.1
       scule: 1.3.0
-      semver: 7.8.2
+      semver: 7.8.3
       std-env: 4.1.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
@@ -11066,10 +11061,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.8.2: {}
-
-  semver@7.8.3:
-    optional: true
+  semver@7.8.3: {}
 
   send@1.2.0:
     dependencies:
@@ -11786,7 +11778,7 @@ snapshots:
       eslint-visitor-keys: 5.0.1
       espree: 11.1.1
       esquery: 1.7.0
-      semver: 7.8.2
+      semver: 7.8.3
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## 0.9.2

Cuts the 0.9.2 patch release: version bump to `0.9.2` and the
`[0.9.2]` CHANGELOG section finalising the changes already merged to
`main`, plus a lockfile dedupe.

### What ships in 0.9.2

- **`withAbbreviations(tokens)` export** — extends
  `unicorn/prevent-abbreviations` with project-specific allowed
  identifiers, re-emitting the complete merged rule options (ESLint
  replaces rule options wholesale rather than deep-merging).
- **JSON recommended-disables restored** — `strict`,
  `no-unused-expressions`, and `no-unused-vars` were being silently
  dropped on JSON/JSONC files by a positional `[2].rules` read, so
  these core rules leaked onto JSON when enabled globally. A new
  `mergeRules` helper folds rules across every config entry.
- **`oxc-parser` override dropped** — a Jul-2025 CI native-bindings
  workaround, confirmed no longer needed; dependency ranges
  normalised to `^` for non-`0.0.x` deps (`tailwind-csstree`
  `~0.3.0` → `^0.3.0`).

### Also in this branch

- **`semver` dedupe** — collapsed the redundant `semver@7.8.2` onto
  the existing `7.8.3` that every transitive consumer already
  satisfies (lockfile only).

### Notes

- Patch release — `withAbbreviations` is a new export but the surface
  is additive and back-compatible.
- Validation left to CI (`build`, `compat` matrix); the underlying
  code changes were already gated on their own PRs into `main`.
