### PR TITLE
ci: group renovate updates by rule impact, skip bots in Claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,7 +6,14 @@ on:
 
 jobs:
   claude-review:
-    if: github.actor != 'renovate[bot]' && !github.event.pull_request.draft
+    # claude-code-action refuses bot-initiated runs, and fails the job
+    # instead of skipping it, so every bot has to be filtered out here.
+    # sender.type is the same field the action checks; the login suffix
+    # is a second reading of it in case the payload shape differs.
+    if: |
+      github.event.sender.type != 'Bot' &&
+      !endsWith(github.actor, '[bot]') &&
+      !github.event.pull_request.draft
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,27 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
+      "description": "Build, test and packaging tooling. Nothing here reaches a consumer's rule set, so a green gate is the whole review. Majors stay individual so one broken tool cannot hold up the rest.",
+      "groupName": "dev tooling",
+      "groupSlug": "dev-tooling",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["digest", "minor", "patch", "pin"],
+      "matchPackageNames": [
+        "!@eslint/js",
+        "!@vue/compiler-sfc",
+        "!eslint",
+        "!typescript"
+      ]
+    },
+    {
+      "description": "Workflow actions cannot change lint output at all. Majors stay individual: publish.yml only runs on release, so an actions major can pass every build and still break publishing.",
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "minor", "patch", "pin", "pinDigest"],
+      "matchPackageNames": ["!node"]
+    },
+    {
       "groupName": "Nuxt.js",
       "groupSlug": "nuxt",
       "matchPackageNames": [
@@ -14,6 +35,12 @@
         "nuxt",
         "/^nuxt-.*$/"
       ]
+    },
+    {
+      "description": "playground-eslint9 pins the lower bound of the eslint and typescript peer ranges deliberately. Bumping it would leave nothing exercising the floor.",
+      "matchFileNames": ["examples/playground-eslint9/package.json"],
+      "matchPackageNames": ["@eslint/js", "eslint", "typescript"],
+      "enabled": false
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
## Summary

Two CI configuration changes. Renovate groups updates that cannot
reach a consumer's rule set. The Claude review job skips every bot
rather than only renovate.

No source, dependency or published output changes.

## Changes

- **ci(renovate): group updates that cannot change lint output** —
  adds three `packageRules`. "dev tooling" groups non-major
  `devDependencies`; "GitHub Actions" groups non-major updates from
  the `github-actions` manager; renovate is disabled for `eslint`,
  `@eslint/js` and `typescript` under `examples/playground-eslint9`,
  which pins the lower bound of the peer ranges.
- **fix(ci): skip the Claude review job for every bot** — the job
  condition named `renovate[bot]` alone, so dependabot reached the
  action, which fails rather than skips on a bot-initiated run
  ("Workflow initiated by non-human actor"). The condition now guards
  on `sender.type`, the field the action itself reads.

## What each group covers

The "dev tooling" rule matches `matchDepTypes: ["devDependencies"]`,
so root `dependencies` are unaffected and continue to arrive as
individual PRs. `eslint`, `@eslint/js`, `typescript` and
`@vue/compiler-sfc` are excluded by name, being peers that also appear
as devDependencies.

Both groups take `digest`, `minor`, `patch` and `pin` only, so majors
continue to arrive individually. `node` is excluded from the actions
group, so the `setup-node` version pin also stays individual.

The existing Nuxt group is unchanged and still takes majors.

## CI

Green on the pushed branch: Build (`make`), Compat (20, 22, 24) and
renovate-config-validator, which re-checks `renovate.json` with
`--strict`.

Neither Claude workflow runs on a branch push. Opening this PR does
not exercise the new condition either, since the author is not a bot,
and the action refuses to run when the branch's copy of the workflow
differs from `main`. The condition takes effect for bot PRs raised or
rebased after this merges.

Renovate reads its configuration from the default branch, so the
grouping takes effect on merge rather than on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated pull request reviews now skip all bot-initiated and draft pull requests.
  * Dependency updates are grouped more efficiently, including development dependencies and GitHub Actions updates.
  * Selected dependency updates in the ESLint playground remain disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->